### PR TITLE
Allow yielding bot response objects directly

### DIFF
--- a/src/fastapi_poe/base.py
+++ b/src/fastapi_poe/base.py
@@ -176,7 +176,6 @@ class PoeBot:
                     yield event
                 elif isinstance(event, ErrorResponse):
                     yield self.error_event(event.text, allow_retry=event.allow_retry)
-                    continue
                 elif isinstance(event, MetaResponse):
                     yield self.meta_event(
                         content_type=event.content_type,
@@ -184,7 +183,6 @@ class PoeBot:
                         linkify=event.linkify,
                         suggested_replies=event.suggested_replies,
                     )
-                    continue
                 elif event.is_suggested_reply:
                     yield self.suggested_reply_event(event.text)
                 elif event.is_replace_response:

--- a/src/fastapi_poe/client.py
+++ b/src/fastapi_poe/client.py
@@ -14,7 +14,14 @@ from typing import Any, AsyncGenerator, Callable, Dict, List, Optional, cast
 import httpx
 import httpx_sse
 
-from .types import ContentType, Identifier, QueryRequest, SettingsResponse
+from .types import (
+    ContentType,
+    Identifier,
+    MetaResponse as MetaMessage,
+    PartialResponse as BotMessage,
+    QueryRequest,
+    SettingsResponse,
+)
 
 PROTOCOL_VERSION = "1.0"
 MESSAGE_LENGTH_LIMIT = 10_000
@@ -35,30 +42,6 @@ class BotErrorNoRetry(BotError):
 
 class InvalidBotSettings(Exception):
     """Raised when a bot returns invalid settings."""
-
-
-@dataclass
-class BotMessage:
-    """Representation of a (possibly partial) response from a bot."""
-
-    text: str  # text of the message so far
-    raw_response: object
-    full_prompt: Optional[str]
-    request_id: Optional[str] = None
-    is_suggested_reply: bool = False
-
-    # "is_replace_response" - represents if this text
-    # should completely replace the previous bot text.
-    is_replace_response: bool = False
-
-
-@dataclass
-class MetaMessage(BotMessage):
-    """Communicate 'meta' events from server bots."""
-
-    linkify: bool = True
-    suggested_replies: bool = True
-    content_type: ContentType = "text/markdown"
 
 
 def _safe_ellipsis(obj: object, limit: int) -> str:
@@ -216,8 +199,8 @@ class _BotContext:
                         error_reported = True
                         continue
                     yield MetaMessage(
-                        "",
-                        data,
+                        text="",
+                        raw_response=data,
                         full_prompt=repr(request),
                         linkify=linkify,
                         suggested_replies=send_suggested_replies,

--- a/src/fastapi_poe/samples/echo.py
+++ b/src/fastapi_poe/samples/echo.py
@@ -9,16 +9,14 @@ from __future__ import annotations
 
 from typing import AsyncIterable
 
-from sse_starlette.sse import ServerSentEvent
-
 from fastapi_poe import PoeBot, run
-from fastapi_poe.types import QueryRequest
+from fastapi_poe.types import PartialResponse, QueryRequest
 
 
 class EchoBot(PoeBot):
-    async def get_response(self, query: QueryRequest) -> AsyncIterable[ServerSentEvent]:
+    async def get_response(self, query: QueryRequest) -> AsyncIterable[PartialResponse]:
         last_message = query.query[-1].content
-        yield self.text_event(last_message)
+        yield PartialResponse(text=last_message)
 
 
 if __name__ == "__main__":

--- a/src/fastapi_poe/types.py
+++ b/src/fastapi_poe/types.py
@@ -82,3 +82,46 @@ class SettingsResponse(BaseModel):
     server_bot_dependencies: Dict[str, int] = Field(default_factory=dict)
     allow_attachments: bool = False
     introduction_message: str = ""
+
+
+class PartialResponse(BaseModel):
+    """Representation of a (possibly partial) response from a bot."""
+
+    text: str
+    """Partial response text.
+
+    If the final bot response is "ABC", you may see a sequence
+    of PartialResponse objects like PartialResponse(text="A"),
+    PartialResponse(text="B"), PartialResponse(text="C").
+
+    """
+
+    raw_response: object = None
+    """For debugging, the raw response from the bot."""
+
+    full_prompt: Optional[str] = None
+    """For debugging, contains the full prompt as sent to the bot."""
+
+    request_id: Optional[str] = None
+    """May be set to an internal identifier for the request."""
+
+    is_suggested_reply: bool = False
+    """If true, this is a suggested reply."""
+
+    is_replace_response: bool = False
+    """If true, this text should completely replace the previous bot text."""
+
+
+class ErrorResponse(PartialResponse):
+    """Communicate errors from server bots."""
+
+    allow_retry: bool = False
+
+
+class MetaResponse(PartialResponse):
+    """Communicate 'meta' events from server bots."""
+
+    linkify: bool = True
+    suggested_replies: bool = True
+    content_type: ContentType = "text/markdown"
+    refetch_settings: bool = False


### PR DESCRIPTION
Should make integrating with client.py easier. Old code will continue to work.
