### PR TITLE
Require pydantic 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "uvicorn",
     "httpx",
     "httpx-sse",
+    "pydantic>2",
 ]
 
 [project.urls]


### PR DESCRIPTION
We use `.model_copy()` which is only in Pydantic 2