### PR TITLE
client: Retry on RemoteProtocolError

### DIFF
--- a/src/fastapi_poe/client.py
+++ b/src/fastapi_poe/client.py
@@ -312,7 +312,10 @@ async def stream_request(
                 raise
             except Exception as e:
                 on_error(e, f"Bot request to {bot_name} failed on try {i}")
-                if got_response or i == num_tries - 1:
+                # Want to retry on some errors even if we have streamed part of the request
+                #   RemoteProtocolError: peer closed connection without sending complete message body
+                allow_retry_after_response = isinstance(e, httpx.RemoteProtocolError)
+                if (got_response and not allow_retry_after_response) or i == num_tries - 1:
                     # If it's a BotError, it probably has a good error message
                     # that we want to show directly.
                     if isinstance(e, BotError):

--- a/src/fastapi_poe/client.py
+++ b/src/fastapi_poe/client.py
@@ -313,9 +313,11 @@ async def stream_request(
             except Exception as e:
                 on_error(e, f"Bot request to {bot_name} failed on try {i}")
                 # Want to retry on some errors even if we have streamed part of the request
-                #   RemoteProtocolError: peer closed connection without sending complete message body
+                # RemoteProtocolError: peer closed connection without sending complete message body
                 allow_retry_after_response = isinstance(e, httpx.RemoteProtocolError)
-                if (got_response and not allow_retry_after_response) or i == num_tries - 1:
+                if (
+                    got_response and not allow_retry_after_response
+                ) or i == num_tries - 1:
                     # If it's a BotError, it probably has a good error message
                     # that we want to show directly.
                     if isinstance(e, BotError):


### PR DESCRIPTION
Should be okay to retry on this error in the middle of the request.