### PR TITLE
fastapi_poe client: `post_message_attachment` improvements

### DIFF
--- a/src/fastapi_poe/types.py
+++ b/src/fastapi_poe/types.py
@@ -86,6 +86,9 @@ class SettingsResponse(BaseModel):
     allow_attachments: bool = False
     introduction_message: str = ""
 
+class AttachmentUploadResponse(BaseModel):
+    inline_ref: Optional[str]
+
 
 class PartialResponse(BaseModel):
     """Representation of a (possibly partial) response from a bot."""


### PR DESCRIPTION
Changed `post_message_attachment` so it now returns the parsed response of its upload request.

Added `is_inline` and `content_type` arguments

Removed the async lock that didn't seem to be protecting anything

Added typing