### PR TITLE
Attachment upload API improvements

### DIFF
--- a/src/fastapi_poe/__init__.py
+++ b/src/fastapi_poe/__init__.py
@@ -18,6 +18,8 @@ __all__ = [
     "ErrorResponse",
     "MetaResponse",
     "ToolDefinition",
+    "AttachFileResponse",
+    "ImageResponse"
 ]
 
 from .base import PoeBot, make_app, run
@@ -29,8 +31,10 @@ from .client import (
     stream_request,
 )
 from .types import (
+    AttachFileResponse,
     Attachment,
     ErrorResponse,
+    ImageResponse,
     MetaResponse,
     PartialResponse,
     ProtocolMessage,

--- a/src/fastapi_poe/base.py
+++ b/src/fastapi_poe/base.py
@@ -94,7 +94,7 @@ class PoeBot:
     # Override these for your bot
     async def get_response(
         self, request: QueryRequest
-    ) -> AsyncIterable[Union[PartialResponse, ServerSentEvent]]:
+    ) -> AsyncIterable[Union[PartialResponse, AttachFileResponse, ServerSentEvent]]:
         """Override this to return a response to user queries."""
         yield self.text_event("hello")
 

--- a/src/fastapi_poe/types.py
+++ b/src/fastapi_poe/types.py
@@ -257,6 +257,7 @@ class AttachFileResponse:
     description: Optional[str] = None
 
 
+@dataclass
 class ImageResponse(AttachFileResponse):
     is_inline: bool = True
 

--- a/src/fastapi_poe/types.py
+++ b/src/fastapi_poe/types.py
@@ -237,6 +237,20 @@ class MetaResponse(PartialResponse):
     refetch_settings: bool = False
 
 
+class AttachFileResponse(PartialResponse):
+    """Communicate attachment files from server bots."""
+
+    file_data: Union[bytes, BinaryIO]
+    filename: str
+    content_type: Optional[str] = None
+    is_inline: bool = False
+    description: Optional[str] = None
+
+
+class ImageResponse(AttachFileResponse):
+    is_inline: bool = True
+
+
 class ToolDefinition(BaseModel):
     class FunctionDefinition(BaseModel):
         class ParametersDefinition(BaseModel):

--- a/src/fastapi_poe/types.py
+++ b/src/fastapi_poe/types.py
@@ -1,6 +1,7 @@
 import asyncio
 import httpx
 import logging
+from dataclasses import dataclass
 from typing import Any, BinaryIO, Dict, List, Optional, Set, Union
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -245,7 +246,8 @@ class MetaResponse(PartialResponse):
     refetch_settings: bool = False
 
 
-class AttachFileResponse(PartialResponse):
+@dataclass
+class AttachFileResponse:
     """Communicate attachment files from server bots."""
 
     file_data: Union[bytes, BinaryIO]

--- a/src/fastapi_poe/types.py
+++ b/src/fastapi_poe/types.py
@@ -74,6 +74,7 @@ class QueryRequest(BaseRequest):
     stop_sequences: List[str] = []
 
     _pending_tasks: Set[asyncio.Task] = set()
+    _attachment_upload_url = "https://www.quora.com/poe_api/file_attachment_3RD_PARTY_POST"
 
     async def post_message_attachment(
         self,
@@ -108,8 +109,6 @@ class QueryRequest(BaseRequest):
         content_type: Optional[str] = None,
         is_inline: bool = False,
     ) -> AttachmentUploadResponse:
-        url = "https://www.quora.com/poe_api/file_attachment_3RD_PARTY_POST"
-
         async with httpx.AsyncClient(timeout=120) as client:
             try:
                 headers = {"Authorization": f"{self.access_key}"}
@@ -123,7 +122,12 @@ class QueryRequest(BaseRequest):
                         "is_inline": is_inline,
                         "download_url": download_url,
                     }
-                    request = httpx.Request("POST", url, data=data, headers=headers)
+                    request = httpx.Request(
+                        "POST",
+                        self._attachment_upload_url,
+                        data=data,
+                        headers=headers
+                    )
                 elif file_data and filename:
                     data = {"message_id": self.message_id, "is_inline": is_inline}
                     files = {
@@ -134,7 +138,11 @@ class QueryRequest(BaseRequest):
                         )
                     }
                     request = httpx.Request(
-                        "POST", url, files=files, data=data, headers=headers
+                        "POST",
+                        self._attachment_upload_url,
+                        files=files,
+                        data=data,
+                        headers=headers
                     )
                 else:
                     raise InvalidParameterError(


### PR DESCRIPTION
Creates new `AttachFileResponse` and `ImageResponse` objects that bots can yield instead of needing to use `post_message_attachment` directly

Moved `post_message_attachment` onto `QueryRequest` so developers don't need to find and pass in the message id and access key. Kept the old `post_message_attachment` on `PoeBot` for compatibility.