### PR TITLE
Attachment upload API improvements

### DIFF
--- a/src/fastapi_poe/__init__.py
+++ b/src/fastapi_poe/__init__.py
@@ -18,6 +18,8 @@ __all__ = [
     "ErrorResponse",
     "MetaResponse",
     "ToolDefinition",
+    "AttachFileResponse",
+    "ImageResponse",
 ]
 
 from .base import PoeBot, make_app, run
@@ -29,8 +31,10 @@ from .client import (
     stream_request,
 )
 from .types import (
+    AttachFileResponse,
     Attachment,
     ErrorResponse,
+    ImageResponse,
     MetaResponse,
     PartialResponse,
     ProtocolMessage,

--- a/src/fastapi_poe/types.py
+++ b/src/fastapi_poe/types.py
@@ -45,6 +45,14 @@ class ProtocolMessage(BaseModel):
     attachments: List[Attachment] = Field(default_factory=list)
 
 
+class InvalidParameterError(Exception):
+    pass
+
+
+class AttachmentUploadError(Exception):
+    pass
+
+
 class BaseRequest(BaseModel):
     """Common data for all requests."""
 
@@ -238,6 +246,22 @@ class MetaResponse(PartialResponse):
     suggested_replies: bool = True
     content_type: ContentType = "text/markdown"
     refetch_settings: bool = False
+
+
+@dataclass
+class AttachFileResponse:
+    """Communicate attachment files from server bots."""
+
+    file_data: Union[bytes, BinaryIO]
+    filename: str
+    content_type: Optional[str] = None
+    is_inline: bool = False
+    description: Optional[str] = None
+
+
+@dataclass
+class ImageResponse(AttachFileResponse):
+    is_inline: bool = True
 
 
 class ToolDefinition(BaseModel):


### PR DESCRIPTION
This moves `post_message_attachment` onto `QueryRequest` so bot creators no longer need to find their access key and message id to upload attachments.

This creates new `AttachFileResponse` and `ImageResponse` objects that the bot can yield to attach files and images to the messages instead of using `post_message_attachment` directly.