### PR TITLE
Attachment upload API improvements 

### DIFF
--- a/src/fastapi_poe/__init__.py
+++ b/src/fastapi_poe/__init__.py
@@ -18,6 +18,8 @@ __all__ = [
     "ErrorResponse",
     "MetaResponse",
     "ToolDefinition",
+    "AttachFileResponse",
+    "ImageResponse",
 ]
 
 from .base import PoeBot, make_app, run
@@ -29,8 +31,10 @@ from .client import (
     stream_request,
 )
 from .types import (
+    AttachFileResponse,
     Attachment,
     ErrorResponse,
+    ImageResponse,
     MetaResponse,
     PartialResponse,
     ProtocolMessage,

--- a/src/fastapi_poe/base.py
+++ b/src/fastapi_poe/base.py
@@ -4,6 +4,7 @@ import copy
 import json
 import logging
 import os
+import re
 import sys
 import warnings
 from typing import AsyncIterable, BinaryIO, Dict, Optional, Union
@@ -17,10 +18,13 @@ from sse_starlette.sse import EventSourceResponse, ServerSentEvent
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from fastapi_poe.types import (
+    AttachFileResponse,
+    AttachmentUploadError,
     AttachmentUploadResponse,
     ContentType,
     ErrorResponse,
     Identifier,
+    InvalidParameterError,
     MetaResponse,
     PartialResponse,
     QueryRequest,
@@ -31,14 +35,6 @@ from fastapi_poe.types import (
 )
 
 logger = logging.getLogger("uvicorn.default")
-
-
-class InvalidParameterError(Exception):
-    pass
-
-
-class AttachmentUploadError(Exception):
-    pass
 
 
 class LoggingMiddleware(BaseHTTPMiddleware):
@@ -98,7 +94,7 @@ class PoeBot:
     # Override these for your bot
     async def get_response(
         self, request: QueryRequest
-    ) -> AsyncIterable[Union[PartialResponse, ServerSentEvent]]:
+    ) -> AsyncIterable[Union[PartialResponse, AttachFileResponse, ServerSentEvent]]:
         """Override this to return a response to user queries."""
         yield self.text_event("hello")
 
@@ -161,8 +157,6 @@ class PoeBot:
         content_type: Optional[str] = None,
         is_inline: bool = False,
     ) -> AttachmentUploadResponse:
-        url = "https://www.quora.com/poe_api/file_attachment_3RD_PARTY_POST"
-
         async with httpx.AsyncClient(timeout=120) as client:
             try:
                 headers = {"Authorization": f"{access_key}"}
@@ -176,7 +170,9 @@ class PoeBot:
                         "is_inline": is_inline,
                         "download_url": download_url,
                     }
-                    request = httpx.Request("POST", url, data=data, headers=headers)
+                    request = httpx.Request(
+                        "POST", self._attachment_upload_url, data=data, headers=headers
+                    )
                 elif file_data and filename:
                     data = {"message_id": message_id, "is_inline": is_inline}
                     files = {
@@ -187,7 +183,11 @@ class PoeBot:
                         )
                     }
                     request = httpx.Request(
-                        "POST", url, files=files, data=data, headers=headers
+                        "POST",
+                        self._attachment_upload_url,
+                        files=files,
+                        data=data,
+                        headers=headers,
                     )
                 else:
                     raise InvalidParameterError(
@@ -208,10 +208,11 @@ class PoeBot:
                 logger.error("An HTTP error occurred when attempting to attach file")
                 raise
 
-    async def _process_pending_attachment_requests(self, message_id):
+    async def _process_pending_attachment_requests(self, request: QueryRequest) -> None:
         try:
             await asyncio.gather(
-                *self._pending_file_attachment_tasks.pop(message_id, [])
+                *self._pending_file_attachment_tasks.pop(request.message_id, []),
+                *request._pending_tasks,
             )
         except Exception:
             logger.error("Error processing pending attachment requests")
@@ -269,7 +270,19 @@ class PoeBot:
             data["error_type"] = error_type
         return ServerSentEvent(data=json.dumps(data), event="error")
 
+    @staticmethod
+    def inline_attachment_event(*, inline_ref: str, description: Optional[str] = None):
+        if description:
+            text = f"![{_markdown_escape(description)}][{inline_ref}]"
+        else:
+            text = f"![{inline_ref}]"
+        return ServerSentEvent(data=json.dumps({"text": text}), event="text")
+
     # Internal handlers
+
+    _attachment_upload_url = (
+        "https://www.quora.com/poe_api/file_attachment_3RD_PARTY_POST"
+    )
 
     async def handle_report_feedback(
         self, feedback_request: ReportFeedbackRequest
@@ -307,6 +320,25 @@ class PoeBot:
                         linkify=event.linkify,
                         suggested_replies=event.suggested_replies,
                     )
+                elif isinstance(event, AttachFileResponse):
+                    upload_task = asyncio.create_task(
+                        request.post_message_attachment(
+                            file_data=event.file_data,
+                            filename=event.filename,
+                            content_type=event.content_type,
+                            is_inline=event.is_inline,
+                        )
+                    )
+                    if event.is_inline:
+                        upload_response = await upload_task
+                        if not upload_response.inline_ref:
+                            raise AttachmentUploadError(
+                                "Attachment upload failed, no inline_ref returned."
+                            )
+                        yield self.inline_attachment_event(
+                            inline_ref=upload_response.inline_ref,
+                            description=event.description or event.filename,
+                        )
                 elif event.is_suggested_reply:
                     yield self.suggested_reply_event(event.text)
                 elif event.is_replace_response:
@@ -317,11 +349,20 @@ class PoeBot:
             logger.exception("Error responding to query")
             yield self.error_event(repr(e), allow_retry=False)
         try:
-            await self._process_pending_attachment_requests(request.message_id)
+            await self._process_pending_attachment_requests(request)
         except Exception as e:
             logger.exception("Error processing pending attachment requests")
             yield self.error_event(repr(e), allow_retry=False)
         yield self.done_event()
+
+
+ASCII_PUNCTUATION_CAPTURE_REGEX = re.compile(
+    r"""([!"#$%&'()*+,\-.\/:;<=>?@\[\\\]^_`{|}~])"""
+)
+
+
+def _markdown_escape(text: str) -> str:
+    return ASCII_PUNCTUATION_CAPTURE_REGEX.sub(r"\\\1", text)
 
 
 def _find_access_key(*, access_key: str, api_key: str) -> Optional[str]:

--- a/src/fastapi_poe/types.py
+++ b/src/fastapi_poe/types.py
@@ -250,6 +250,22 @@ class MetaResponse(PartialResponse):
     refetch_settings: bool = False
 
 
+@dataclass
+class AttachFileResponse:
+    """Communicate attachment files from server bots."""
+
+    file_data: Union[bytes, BinaryIO]
+    filename: str
+    content_type: Optional[str] = None
+    is_inline: bool = False
+    description: Optional[str] = None
+
+
+@dataclass
+class ImageResponse(AttachFileResponse):
+    is_inline: bool = True
+
+
 class ToolDefinition(BaseModel):
     class FunctionDefinition(BaseModel):
         class ParametersDefinition(BaseModel):

--- a/src/fastapi_poe/types.py
+++ b/src/fastapi_poe/types.py
@@ -1,8 +1,14 @@
-from typing import Any, Dict, List, Optional
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Any, BinaryIO, Dict, List, Optional, Set, Union
 
+import httpx
 from fastapi import Request
 from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import Literal, TypeAlias
+
+logger = logging.getLogger("uvicorn.default")
 
 Identifier: TypeAlias = str
 FeedbackType: TypeAlias = Literal["like", "dislike"]
@@ -23,6 +29,10 @@ class Attachment(BaseModel):
     name: str
 
 
+class AttachmentUploadResponse(BaseModel):
+    inline_ref: Optional[str]
+
+
 class ProtocolMessage(BaseModel):
     """A message as used in the Poe protocol."""
 
@@ -33,6 +43,14 @@ class ProtocolMessage(BaseModel):
     message_id: str = ""
     feedback: List[MessageFeedback] = Field(default_factory=list)
     attachments: List[Attachment] = Field(default_factory=list)
+
+
+class InvalidParameterError(Exception):
+    pass
+
+
+class AttachmentUploadError(Exception):
+    pass
 
 
 class BaseRequest(BaseModel):
@@ -60,6 +78,95 @@ class QueryRequest(BaseRequest):
     skip_system_prompt: bool = False
     logit_bias: Dict[str, float] = {}
     stop_sequences: List[str] = []
+
+    _pending_tasks: Set[asyncio.Task] = set()
+    _attachment_upload_url = (
+        "https://www.quora.com/poe_api/file_attachment_3RD_PARTY_POST"
+    )
+
+    async def post_message_attachment(
+        self,
+        *,
+        download_url: Optional[str] = None,
+        file_data: Optional[Union[bytes, BinaryIO]] = None,
+        filename: Optional[str] = None,
+        content_type: Optional[str] = None,
+        is_inline: bool = False,
+    ) -> AttachmentUploadResponse:
+        task = asyncio.create_task(
+            self._make_file_attachment_request(
+                download_url=download_url,
+                file_data=file_data,
+                filename=filename,
+                content_type=content_type,
+                is_inline=is_inline,
+            )
+        )
+        self._pending_tasks.add(task)
+        try:
+            return await task
+        finally:
+            self._pending_tasks.remove(task)
+
+    async def _make_file_attachment_request(
+        self,
+        *,
+        download_url: Optional[str] = None,
+        file_data: Optional[Union[bytes, BinaryIO]] = None,
+        filename: Optional[str] = None,
+        content_type: Optional[str] = None,
+        is_inline: bool = False,
+    ) -> AttachmentUploadResponse:
+        async with httpx.AsyncClient(timeout=120) as client:
+            try:
+                headers = {"Authorization": f"{self.access_key}"}
+                if download_url:
+                    if file_data or filename:
+                        raise InvalidParameterError(
+                            "Cannot provide filename or file_data if download_url is provided."
+                        )
+                    data = {
+                        "message_id": self.message_id,
+                        "is_inline": is_inline,
+                        "download_url": download_url,
+                    }
+                    request = httpx.Request(
+                        "POST", self._attachment_upload_url, data=data, headers=headers
+                    )
+                elif file_data and filename:
+                    data = {"message_id": self.message_id, "is_inline": is_inline}
+                    files = {
+                        "file": (
+                            (filename, file_data)
+                            if content_type is None
+                            else (filename, file_data, content_type)
+                        )
+                    }
+                    request = httpx.Request(
+                        "POST",
+                        self._attachment_upload_url,
+                        files=files,
+                        data=data,
+                        headers=headers,
+                    )
+                else:
+                    raise InvalidParameterError(
+                        "Must provide either download_url or file_data and filename."
+                    )
+                response = await client.send(request)
+
+                if response.status_code != 200:
+                    raise AttachmentUploadError(
+                        f"{response.status_code}: {response.reason_phrase}"
+                    )
+
+                return AttachmentUploadResponse(
+                    inline_ref=response.json().get("inline_ref")
+                )
+
+            except httpx.HTTPError:
+                logger.error("An HTTP error occurred when attempting to attach file")
+                raise
 
 
 class SettingsRequest(BaseRequest):
@@ -90,10 +197,6 @@ class SettingsResponse(BaseModel):
     server_bot_dependencies: Dict[str, int] = Field(default_factory=dict)
     allow_attachments: bool = False
     introduction_message: str = ""
-
-
-class AttachmentUploadResponse(BaseModel):
-    inline_ref: Optional[str]
 
 
 class PartialResponse(BaseModel):


### PR DESCRIPTION
This moves post_message_attachment onto QueryRequest so bot creators no longer need to find their access key and message id to upload attachments.

This creates new AttachFileResponse and ImageResponse objects that the bot can yield to attach files and images to the messages instead of using post_message_attachment directly.

