### PR TITLE
Modernize PyPI publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,9 +6,14 @@ name: Publish Python distributions to PyPI and TestPyPI
 on: push
 
 jobs:
-  build-n-publish:
+  release:
     name: Build and publish Python distributions to PyPI and TestPyPI
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
+    environment:
+      name: pypi
+      url: https://pypi.org/project/fastapi-poe/
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.10
@@ -23,6 +28,4 @@ jobs:
           python -m build --sdist --wheel --outdir dist/ .
       - name: Publish distribution to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,31 +1,49 @@
 # Based on
 # https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
 
-name: Publish Python distributions to PyPI and TestPyPI
+name: Publish Python distribution to PyPI
 
 on: push
 
 jobs:
-  release:
-    name: Build and publish Python distributions to PyPI and TestPyPI
+  build:
+    name: Build distribution
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
-    environment:
-      name: pypi
-      url: https://pypi.org/project/fastapi-poe/
+
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python 3.10
+      - uses: actions/checkout@v4
+      - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.x"
       - name: Install pypa/build
-        run: >-
-          python -m pip install build --user
-      - name: Build a binary wheel and a source tarball (fastapi-poe)
-        run: >-
-          python -m build --sdist --wheel --outdir dist/ .
+        run: python3 -m pip install --user build
+      - name: Build a binary wheel and a source tarball
+        run: python3 -m build
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-to-pypi:
+    name: >-
+      Publish Python distribution to PyPI
+    if: startsWith(github.ref, 'refs/tags/') # only publish to PyPI on tag pushes
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/fastapi-poe
+    permissions:
+      id-token: write # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
       - name: Publish distribution to PyPI
-        if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
- Use Trusted Publishers
- Do not use "master" version of the GitHub action
