### PR TITLE
Use Ruff and enforce full type annotation coverage

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,6 +34,8 @@ jobs:
           python -m pip install . pytest
 
       - uses: jakebailey/pyright-action@v1
+        with:
+          verify-types: fastapi_poe
 
   tests:
     name: unit tests

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,16 +35,6 @@ jobs:
 
       - uses: jakebailey/pyright-action@v1
 
-  ruff:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: chartboost/ruff-action@v1
-        with:
-          version: 0.1.14
-
   tests:
     name: unit tests
     timeout-minutes: 10

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,8 +34,16 @@ jobs:
           python -m pip install . pytest
 
       - uses: jakebailey/pyright-action@v1
+
+  ruff:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: chartboost/ruff-action@v1
         with:
-          verify-types: fastapi_poe
+          version: 0.1.14
 
   tests:
     name: unit tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,22 +1,9 @@
 repos:
-  # Order matters because pyupgrade may make changes that pycln and black have to clean up
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.8.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.14
     hooks:
-      - id: pyupgrade
-        args: [--py37-plus]
-
-  - repo: https://github.com/hadialqattan/pycln
-    rev: v2.1.5
-    hooks:
-      - id: pycln
-        args: [--config=pyproject.toml]
-
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        name: isort (python)
+      - id: ruff
+        args: [--fix]
 
   - repo: https://github.com/psf/black
     rev: 23.3.0
@@ -29,15 +16,6 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          - flake8-bugbear
-          - flake8-comprehensions
-          - flake8-simplify
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.0-alpha.9-for-vscode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,25 @@ select = [
   "B",  # bugbear
   "SIM",  # simplify
   "UP",  # pyupgrade
+  "PIE810",  # startswith/endswith with a tuple
+  "SIM101",  # mergeable isinstance() calls
+  "SIM201",  # "not ... == ..." -> "... != ..."
+  "SIM202",  # "not ... != ..." -> "... == ..."
+  "C400",  # unnecessary list() calls
+  "C401",  # unnecessary set() calls
+  "C402",  # unnecessary dict() calls
+  "C403",  # unnecessary listcomp within set() call
+  "C404",  # unnecessary listcomp within dict() call
+  "C405",  # use set literals
+  "C406",  # use dict literals
+  "C409",  # tuple() calls that can be replaced with literals
+  "C410",  # list() calls that can be replaced with literals
+  "C411",  # list() calls with genexps that can be replaced with listcomps
+  "C413",  # unnecessary list() calls around sorted()
+  "C414",  # unnecessary list() calls inside sorted()
+  "C417",  # unnecessary map() calls that can be replaced with listcomps/genexps
+  "C418",  # unnecessary dict() calls that can be replaced with literals
+  "PERF101",  # unnecessary list() calls that can be replaced with literals
 ]
 
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/quora/poe-protocol"
+"Homepage" = "https://developer.poe.com/"
 
 [tool.pyright]
 pythonVersion = "3.7"
@@ -38,10 +38,23 @@ pythonVersion = "3.7"
 target-version = ['py37']
 skip-magic-trailing-comma = true
 
-[tool.pycln]
-all = true
+[tool.ruff]
+select = [
+  "F",
+  "E",
+  "I",  # import sorting
+  "ANN",  # type annotations for everything
+  "C4",  # flake8-comprehensions
+  "B",  # bugbear
+  "SIM",  # simplify
+  "UP",  # pyupgrade
+]
 
-[tool.isort]
-profile = "black"
-combine_as_imports = true
-skip_gitignore = true
+ignore = [
+  "B008",  # do not perform function calls in argument defaults
+  "ANN101",  # missing type annotation for self in method
+  "ANN102",  # missing type annotation for cls in classmethod
+]
+
+line-length = 100
+target-version = "py37"

--- a/src/fastapi_poe/base.py
+++ b/src/fastapi_poe/base.py
@@ -78,8 +78,9 @@ class LoggingMiddleware(BaseHTTPMiddleware):
         return response
 
 
-async def http_exception_handler(request: Request, ex: Exception) -> None:
+async def http_exception_handler(request: Request, ex: Exception) -> Response:
     logger.error(ex)
+    return Response(status_code=500, content="Internal server error")
 
 
 http_bearer = HTTPBearer()

--- a/src/fastapi_poe/client.py
+++ b/src/fastapi_poe/client.py
@@ -17,8 +17,6 @@ import httpx_sse
 from .types import (
     ContentType,
     Identifier,
-    MetaResponse as MetaMessage,
-    PartialResponse as BotMessage,
     ProtocolMessage,
     QueryRequest,
     SettingsResponse,
@@ -26,6 +24,8 @@ from .types import (
     ToolDefinition,
     ToolResultDefinition,
 )
+from .types import MetaResponse as MetaMessage
+from .types import PartialResponse as BotMessage
 
 PROTOCOL_VERSION = "1.0"
 MESSAGE_LENGTH_LIMIT = 10_000
@@ -274,7 +274,7 @@ class _BotContext:
                 {"data": data, "message_id": message_id},
             )
             # If they are returning invalid JSON, retrying immediately probably won't help
-            raise BotErrorNoRetry(f"Invalid JSON in {context!r} event")
+            raise BotErrorNoRetry(f"Invalid JSON in {context!r} event") from None
         if not isinstance(parsed, dict):
             await self.report_error(
                 f"Expected JSON dict in {context!r} event",

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,10 +1,9 @@
 import pydantic
 import pytest
-
 from fastapi_poe.types import PartialResponse
 
 
-def test_extra_attrs():
+def test_extra_attrs() -> None:
     with pytest.raises(pydantic.ValidationError):
         PartialResponse(text="hi", replaceResponse=True)  # type: ignore
 


### PR DESCRIPTION
I got here because I was trying to get rid of some `no-untyped-call` mypy errors internally, which were because our `__init__` method doesn't have annotations. To fix it thoroughly:

- Use Ruff to enforce full annotation coverage
- Also replace other linting tools (pyupgrade, pycln, isort, flake8) so we have fewer tools to worry about
- Update the project URL because I noticed it
- Fix any new errors