### PR TITLE
Improve error messages for post_message_attachment

### DIFF
--- a/src/fastapi_poe/base.py
+++ b/src/fastapi_poe/base.py
@@ -224,8 +224,9 @@ class PoeBot:
                 response = await client.send(request)
 
                 if response.status_code != 200:
+                    error_pieces = [piece async for piece in response.aiter_text()]
                     raise AttachmentUploadError(
-                        f"{response.status_code}: {response.reason_phrase}"
+                        f"{response.status_code} {response.reason_phrase}: {''.join(error_pieces)}"
                     )
 
                 return AttachmentUploadResponse(


### PR DESCRIPTION
Include the text content of the server's error message in addition to the status code. It's hard to debug attachment issues otherwise.