### PR TITLE
Fix get_response_with_context()

### DIFF
--- a/src/fastapi_poe/base.py
+++ b/src/fastapi_poe/base.py
@@ -174,7 +174,6 @@ class PoeBot:
         response to the Poe servers. This is what gets displayed to the user.
 
         """
-        yield self.text_event("hello")
         async for event in self.get_response(request):
             yield event
 


### PR DESCRIPTION
Bots that only override get_response() would emit a spurious extra text event "hello".