### PR TITLE
fastapi_poe: add bot_query_id

### DIFF
--- a/src/fastapi_poe/types.py
+++ b/src/fastapi_poe/types.py
@@ -99,7 +99,9 @@ class QueryRequest(BaseRequest):
     - `skip_system_prompt` (`bool = False`): Whether to use any system prompting or not.
     - `logit_bias` (`Dict[str, float] = {}`)
     - `stop_sequences` (`List[str] = []`)
-    - `language_code` (`str` = "en"`): BCP 47 language code of the user's client.
+    - `language_code` (`str = "en"`): BCP 47 language code of the user's client.
+    - `bot_query_id` (`str = ""`): an identifier representing a bot query. this should be included
+    with requests for point auths/captures.
 
     """
 
@@ -115,6 +117,7 @@ class QueryRequest(BaseRequest):
     logit_bias: Dict[str, float] = {}
     stop_sequences: List[str] = []
     language_code: str = "en"
+    bot_query_id: str = ""
 
 
 class SettingsRequest(BaseRequest):

--- a/src/fastapi_poe/types.py
+++ b/src/fastapi_poe/types.py
@@ -100,8 +100,7 @@ class QueryRequest(BaseRequest):
     - `logit_bias` (`Dict[str, float] = {}`)
     - `stop_sequences` (`List[str] = []`)
     - `language_code` (`str = "en"`): BCP 47 language code of the user's client.
-    - `bot_query_id` (`str = ""`): an identifier representing a bot query. this should be included
-    with requests for point auths/captures.
+    - `bot_query_id` (`str = ""`): an identifier representing a bot query.
 
     """
 
@@ -117,7 +116,7 @@ class QueryRequest(BaseRequest):
     logit_bias: Dict[str, float] = {}
     stop_sequences: List[str] = []
     language_code: str = "en"
-    bot_query_id: str = ""
+    bot_query_id: Identifier = ""
 
 
 class SettingsRequest(BaseRequest):


### PR DESCRIPTION
this is a field that will be required for bot creators to pass along in the point auth/capture requests as part of pay-by-context. this field will be encrypted.

Reviewers:

Test Plan:

Differential Revision:

Asana Tasks:

Screenshot:

CC:

Deploy To: