### PR TITLE
feat: Add support for report_reaction endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fastapi_poe"
-version = "0.0.48"
+version = "0.0.49"
 authors = [
   { name="Lida Li", email="lli@quora.com" },
   { name="Jelle Zijlstra", email="jelle@quora.com" },

--- a/src/fastapi_poe/__init__.py
+++ b/src/fastapi_poe/__init__.py
@@ -27,11 +27,29 @@ __all__ = [
 ]
 
 from .base import PoeBot, make_app, run
-from .client import (BotError, BotErrorNoRetry, get_bot_response,
-                     get_final_response, stream_request, sync_bot_settings)
-from .types import (Attachment, ErrorResponse, MessageFeedback, MetaResponse,
-                    PartialResponse, ProtocolMessage, QueryRequest,
-                    ReportErrorRequest, ReportFeedbackRequest,
-                    ReportReactionRequest, RequestContext, SettingsRequest,
-                    SettingsResponse, ToolCallDefinition, ToolDefinition,
-                    ToolResultDefinition)
+from .client import (
+    BotError,
+    BotErrorNoRetry,
+    get_bot_response,
+    get_final_response,
+    stream_request,
+    sync_bot_settings,
+)
+from .types import (
+    Attachment,
+    ErrorResponse,
+    MessageFeedback,
+    MetaResponse,
+    PartialResponse,
+    ProtocolMessage,
+    QueryRequest,
+    ReportErrorRequest,
+    ReportFeedbackRequest,
+    ReportReactionRequest,
+    RequestContext,
+    SettingsRequest,
+    SettingsResponse,
+    ToolCallDefinition,
+    ToolDefinition,
+    ToolResultDefinition,
+)

--- a/src/fastapi_poe/__init__.py
+++ b/src/fastapi_poe/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
     "QueryRequest",
     "SettingsRequest",
     "ReportFeedbackRequest",
+    "ReportReactionRequest",
     "ReportErrorRequest",
     "SettingsResponse",
     "PartialResponse",
@@ -26,28 +27,11 @@ __all__ = [
 ]
 
 from .base import PoeBot, make_app, run
-from .client import (
-    BotError,
-    BotErrorNoRetry,
-    get_bot_response,
-    get_final_response,
-    stream_request,
-    sync_bot_settings,
-)
-from .types import (
-    Attachment,
-    ErrorResponse,
-    MessageFeedback,
-    MetaResponse,
-    PartialResponse,
-    ProtocolMessage,
-    QueryRequest,
-    ReportErrorRequest,
-    ReportFeedbackRequest,
-    RequestContext,
-    SettingsRequest,
-    SettingsResponse,
-    ToolCallDefinition,
-    ToolDefinition,
-    ToolResultDefinition,
-)
+from .client import (BotError, BotErrorNoRetry, get_bot_response,
+                     get_final_response, stream_request, sync_bot_settings)
+from .types import (Attachment, ErrorResponse, MessageFeedback, MetaResponse,
+                    PartialResponse, ProtocolMessage, QueryRequest,
+                    ReportErrorRequest, ReportFeedbackRequest,
+                    ReportReactionRequest, RequestContext, SettingsRequest,
+                    SettingsResponse, ToolCallDefinition, ToolDefinition,
+                    ToolResultDefinition)

--- a/src/fastapi_poe/base.py
+++ b/src/fastapi_poe/base.py
@@ -247,25 +247,13 @@ class PoeBot:
         """
         await self.on_feedback(feedback_request)
 
-    async def on_reaction(self, reaction_request: ReportReactionRequest) -> None:
-        """
-
-        Override this to record reaction from the user.
-        #### Parameters:
-        - `reaction_request` (`ReportReactionRequest`): An object representing a reaction request
-        from Poe. This is sent out when a user provides reaction on a response on your bot.
-        #### Returns: `None`
-
-        """
-        pass
-
     async def on_reaction_with_context(
         self, reaction_request: ReportReactionRequest, context: RequestContext
     ) -> None:
         """
 
-        A version of `on_reaction` that also includes the request context information. By
-        default, this will call `on_reaction`.
+        Override this to record reaction from the user. This also includes the request context
+        information.
 
         #### Parameters:
         - `reaction_request` (`ReportReactionRequest`): An object representing a reaction request
@@ -274,7 +262,7 @@ class PoeBot:
         #### Returns: `None`
 
         """
-        await self.on_reaction(reaction_request)
+        pass
 
     async def on_error(self, error_request: ReportErrorRequest) -> None:
         """

--- a/src/fastapi_poe/base.py
+++ b/src/fastapi_poe/base.py
@@ -8,8 +8,16 @@ import sys
 import warnings
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import (AsyncIterable, Awaitable, BinaryIO, Callable, Dict,
-                    Optional, Sequence, Union)
+from typing import (
+    AsyncIterable,
+    Awaitable,
+    BinaryIO,
+    Callable,
+    Dict,
+    Optional,
+    Sequence,
+    Union,
+)
 
 import httpx
 from fastapi import Depends, FastAPI, HTTPException, Request, Response
@@ -22,15 +30,27 @@ from starlette.types import Message
 from typing_extensions import deprecated, overload
 
 from fastapi_poe.client import PROTOCOL_VERSION, sync_bot_settings
-from fastapi_poe.templates import (IMAGE_VISION_ATTACHMENT_TEMPLATE,
-                                   TEXT_ATTACHMENT_TEMPLATE,
-                                   URL_ATTACHMENT_TEMPLATE)
-from fastapi_poe.types import (AttachmentUploadResponse, ContentType,
-                               ErrorResponse, Identifier, MetaResponse,
-                               PartialResponse, ProtocolMessage, QueryRequest,
-                               ReportErrorRequest, ReportFeedbackRequest,
-                               ReportReactionRequest, RequestContext,
-                               SettingsRequest, SettingsResponse)
+from fastapi_poe.templates import (
+    IMAGE_VISION_ATTACHMENT_TEMPLATE,
+    TEXT_ATTACHMENT_TEMPLATE,
+    URL_ATTACHMENT_TEMPLATE,
+)
+from fastapi_poe.types import (
+    AttachmentUploadResponse,
+    ContentType,
+    ErrorResponse,
+    Identifier,
+    MetaResponse,
+    PartialResponse,
+    ProtocolMessage,
+    QueryRequest,
+    ReportErrorRequest,
+    ReportFeedbackRequest,
+    ReportReactionRequest,
+    RequestContext,
+    SettingsRequest,
+    SettingsResponse,
+)
 
 logger = logging.getLogger("uvicorn.default")
 
@@ -307,8 +327,7 @@ class PoeBot:
         filename: Optional[str] = None,
         content_type: Optional[str] = None,
         is_inline: bool = False,
-    ) -> AttachmentUploadResponse:
-        ...
+    ) -> AttachmentUploadResponse: ...
 
     # This overload requires all parameters to be passed as keywords
     @overload
@@ -321,8 +340,7 @@ class PoeBot:
         filename: Optional[str] = None,
         content_type: Optional[str] = None,
         is_inline: bool = False,
-    ) -> AttachmentUploadResponse:
-        ...
+    ) -> AttachmentUploadResponse: ...
 
     async def post_message_attachment(
         self,

--- a/src/fastapi_poe/client.py
+++ b/src/fastapi_poe/client.py
@@ -16,18 +16,11 @@ from typing import Any, AsyncGenerator, Callable, Dict, List, Optional, cast
 import httpx
 import httpx_sse
 
-from .types import (
-    ContentType,
-    Identifier,
-    ProtocolMessage,
-    QueryRequest,
-    SettingsResponse,
-    ToolCallDefinition,
-    ToolDefinition,
-    ToolResultDefinition,
-)
+from .types import ContentType, Identifier
 from .types import MetaResponse as MetaMessage
 from .types import PartialResponse as BotMessage
+from .types import (ProtocolMessage, QueryRequest, SettingsResponse,
+                    ToolCallDefinition, ToolDefinition, ToolResultDefinition)
 
 PROTOCOL_VERSION = "1.0"
 MESSAGE_LENGTH_LIMIT = 10_000
@@ -111,6 +104,27 @@ class _BotContext:
                 "user_id": user_id,
                 "conversation_id": conversation_id,
                 "feedback_type": feedback_type,
+            },
+        )
+
+    async def report_reaction(
+        self,
+        message_id: Identifier,
+        user_id: Identifier,
+        conversation_id: Identifier,
+        reaction: str,
+    ) -> None:
+        """Report message reaction to the bot server."""
+        await self.session.post(
+            self.endpoint,
+            headers=self.headers,
+            json={
+                "version": PROTOCOL_VERSION,
+                "type": "report_reaction",
+                "message_id": message_id,
+                "user_id": user_id,
+                "conversation_id": conversation_id,
+                "reaction": reaction,
             },
         )
 

--- a/src/fastapi_poe/client.py
+++ b/src/fastapi_poe/client.py
@@ -16,11 +16,18 @@ from typing import Any, AsyncGenerator, Callable, Dict, List, Optional, cast
 import httpx
 import httpx_sse
 
-from .types import ContentType, Identifier
+from .types import (
+    ContentType,
+    Identifier,
+    ProtocolMessage,
+    QueryRequest,
+    SettingsResponse,
+    ToolCallDefinition,
+    ToolDefinition,
+    ToolResultDefinition,
+)
 from .types import MetaResponse as MetaMessage
 from .types import PartialResponse as BotMessage
-from .types import (ProtocolMessage, QueryRequest, SettingsResponse,
-                    ToolCallDefinition, ToolDefinition, ToolResultDefinition)
 
 PROTOCOL_VERSION = "1.0"
 MESSAGE_LENGTH_LIMIT = 10_000

--- a/src/fastapi_poe/types.py
+++ b/src/fastapi_poe/types.py
@@ -79,7 +79,9 @@ class BaseRequest(BaseModel):
     """Common data for all requests."""
 
     version: str
-    type: Literal["query", "settings", "report_feedback", "report_error"]
+    type: Literal[
+        "query", "settings", "report_feedback", "report_reaction", "report_error"
+    ]
 
 
 class QueryRequest(BaseRequest):
@@ -144,6 +146,24 @@ class ReportFeedbackRequest(BaseRequest):
     user_id: Identifier
     conversation_id: Identifier
     feedback_type: FeedbackType
+
+
+class ReportReactionRequest(BaseRequest):
+    """
+
+    Request parameters for a report_reaction request.
+    #### Fields:
+    - `message_id` (`Identifier`)
+    - `user_id` (`Identifier`)
+    - `conversation_id` (`Identifier`)
+    - `reaction` (`str`)
+
+    """
+
+    message_id: Identifier
+    user_id: Identifier
+    conversation_id: Identifier
+    reaction: str
 
 
 class ReportErrorRequest(BaseRequest):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,6 +1,5 @@
 import pydantic
 import pytest
-
 from fastapi_poe.types import PartialResponse
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,5 +1,6 @@
 import pydantic
 import pytest
+
 from fastapi_poe.types import PartialResponse
 
 


### PR DESCRIPTION
- This is to support message reactions launch. This will replace report_feedback which will be marked deprecated but still functional. Will update documentation around launch time
- Tested end-to-end with server bot running locally and trying different reactions and verifying endpoint is called
- Some formatting changes are in here since I ran all the recommended steps in the documentation
- Updated version to 0.0.49