### PR TITLE
add data_event type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fastapi_poe"
-version = "0.0.55"
+version = "0.0.56"
 authors = [
   { name="Lida Li", email="lli@quora.com" },
   { name="Jelle Zijlstra", email="jelle@quora.com" },

--- a/src/fastapi_poe/__init__.py
+++ b/src/fastapi_poe/__init__.py
@@ -18,6 +18,7 @@ __all__ = [
     "PartialResponse",
     "ErrorResponse",
     "MetaResponse",
+    "DataResponse",
     "RequestContext",
     "ToolDefinition",
     "ToolCallDefinition",
@@ -41,6 +42,7 @@ from .client import (
 from .types import (
     Attachment,
     CostItem,
+    DataResponse,
     ErrorResponse,
     MessageFeedback,
     MetaResponse,

--- a/src/fastapi_poe/base.py
+++ b/src/fastapi_poe/base.py
@@ -33,6 +33,7 @@ from fastapi_poe.types import (
     AttachmentUploadResponse,
     ContentType,
     CostItem,
+    DataResponse,
     ErrorResponse,
     Identifier,
     MetaResponse,
@@ -773,6 +774,10 @@ class PoeBot:
         return ServerSentEvent(data=json.dumps({"text": text}), event="text")
 
     @staticmethod
+    def data_event(metadata: str) -> ServerSentEvent:
+        return ServerSentEvent(data=json.dumps({"metadata": metadata}), event="data")
+
+    @staticmethod
     def replace_response_event(text: str) -> ServerSentEvent:
         return ServerSentEvent(
             data=json.dumps({"text": text}), event="replace_response"
@@ -882,6 +887,8 @@ class PoeBot:
                         linkify=event.linkify,
                         suggested_replies=event.suggested_replies,
                     )
+                elif isinstance(event, DataResponse):
+                    yield self.data_event(event.metadata)
                 elif event.is_suggested_reply:
                     yield self.suggested_reply_event(event.text)
                 elif event.is_replace_response:

--- a/src/fastapi_poe/types.py
+++ b/src/fastapi_poe/types.py
@@ -80,6 +80,7 @@ class ProtocolMessage(BaseModel):
     message_id: str = ""
     feedback: list[MessageFeedback] = Field(default_factory=list)
     attachments: list[Attachment] = Field(default_factory=list)
+    metadata: Optional[str] = None
 
 
 class RequestContext(BaseModel):
@@ -235,6 +236,23 @@ class SettingsResponse(BaseModel):
 class AttachmentUploadResponse(BaseModel):
     inline_ref: Optional[str]
     attachment_url: Optional[str]
+
+
+class DataResponse(BaseModel):
+    """
+
+    A response that contains arbitrary data to attach to the bot response.
+    This data can be retrieved in later requests to the bot within the same chat.
+    Note that only the final DataResponse object in the stream will be attached to the bot response.
+
+    #### Fields:
+    - `metadata` (`str`): String of data to attach to the bot response.
+
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    metadata: str
 
 
 class PartialResponse(BaseModel):


### PR DESCRIPTION
add a new data event type. This will allow bots to attach additional metadata to their current response, so that it can be accessed in future requests (via ProtocolMessage).