### PR TITLE
fix attachment not working when post_message_attachment is called at end

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fastapi_poe"
-version = "0.0.57"
+version = "0.0.58"
 authors = [
   { name="Lida Li", email="lli@quora.com" },
   { name="Jelle Zijlstra", email="jelle@quora.com" },

--- a/src/fastapi_poe/base.py
+++ b/src/fastapi_poe/base.py
@@ -917,7 +917,8 @@ class PoeBot:
                     query_request=request
                 )
             async for event in self.get_response_with_context(request, context):
-                # yield any pending file events from post_message_attachment first
+                # yield any pending file events from post_message_attachment first.
+                # this is to ensure responses with inline_ref are sent after attachment is made.
                 async for pending_file_event in self._yield_pending_file_events(
                     request.message_id
                 ):
@@ -946,6 +947,11 @@ class PoeBot:
                     yield self.replace_response_event(event.text)
                 else:
                     yield self.text_event(event.text)
+            # yield any remaining file events
+            async for pending_file_event in self._yield_pending_file_events(
+                request.message_id
+            ):
+                yield pending_file_event
         except Exception as e:
             logger.exception("Error responding to query")
             yield self.error_event(


### PR DESCRIPTION
if post_message_attachment was the final call in get_response(), the file event wasnt being yielded properly.