### PR TITLE
Monetization: Adding monetization related parameters to SettingsResponse

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fastapi_poe"
-version = "0.0.59"
+version = "0.0.60"
 authors = [
   { name="Lida Li", email="lli@quora.com" },
   { name="Jelle Zijlstra", email="jelle@quora.com" },

--- a/src/fastapi_poe/types.py
+++ b/src/fastapi_poe/types.py
@@ -1,7 +1,7 @@
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from fastapi import Request
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from typing_extensions import Literal, TypeAlias
 
 Identifier: TypeAlias = str
@@ -36,6 +36,17 @@ class CostItem(BaseModel):
 
     amount_usd_milli_cents: int
     description: Optional[str] = None
+
+    @field_validator("amount_usd_milli_cents", mode="before")
+    def validate_amount_is_int(cls, v: Union[int, str, float]) -> int:
+        if not isinstance(v, int):
+            raise ValueError(
+                "Invalid amount: expected an integer for amount_usd_milli_cents, "
+                f"got {type(v)}. Please provide the amount in milli-cents "
+                "(1/1000 of a cent) as a whole number. If you're working with a "
+                "decimal value, consider using math.ceil() to round up."
+            )
+        return v
 
 
 class Attachment(BaseModel):
@@ -224,6 +235,7 @@ class SettingsResponse(BaseModel):
 
     context_clear_window_secs: Optional[int] = None  # deprecated
     allow_user_context_clear: Optional[bool] = None  # deprecated
+    custom_rate_card: Optional[str] = None  # deprecated
     server_bot_dependencies: dict[str, int] = Field(default_factory=dict)
     allow_attachments: Optional[bool] = None
     introduction_message: Optional[str] = None
@@ -231,7 +243,8 @@ class SettingsResponse(BaseModel):
     enable_image_comprehension: Optional[bool] = None
     enforce_author_role_alternation: Optional[bool] = None
     enable_multi_bot_chat_prompting: Optional[bool] = None
-    custom_rate_card: Optional[str] = None
+    rate_card: Optional[str] = None
+    cost_label: Optional[str] = None
 
 
 class AttachmentUploadResponse(BaseModel):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,6 +1,6 @@
 import pydantic
 import pytest
-from fastapi_poe.types import PartialResponse
+from fastapi_poe.types import CostItem, PartialResponse
 
 
 def test_extra_attrs() -> None:
@@ -10,3 +10,18 @@ def test_extra_attrs() -> None:
     resp = PartialResponse(text="a capybara", is_replace_response=True)
     assert resp.is_replace_response is True
     assert resp.text == "a capybara"
+
+
+def test_cost_item() -> None:
+    with pytest.raises(pydantic.ValidationError):
+        CostItem(amount_usd_milli_cents=1.5)  # type: ignore
+
+    with pytest.raises(pydantic.ValidationError):
+        CostItem(amount_usd_milli_cents="1")  # type: ignore
+
+    with pytest.raises(pydantic.ValidationError):
+        CostItem(amount_usd_milli_cents=-2.5)  # type: ignore
+
+    item = CostItem(amount_usd_milli_cents=25)
+    assert item.amount_usd_milli_cents == 25
+    assert item.description is None


### PR DESCRIPTION
- preparing for launching auth and captures for monetized creators
- bumped version to 0.0.60
- deprecated SettingsResponse.custom_rate_card in favour of SettingsResponse.rate_card 