### PR TITLE
feature: bump protocol version to 1.1 and update SettingsResponse accordingly

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -468,9 +468,12 @@ might get updated in the future.
 
 An object representing your bot's response to a settings object.
 #### Fields:
+- `response_version` (`int = 1`): Different Poe Protocol versions use different default settings
+values. When provided, Poe will use the default values for the specified response version.
+If not provided, Poe will use the default values for response version 0.
 - `server_bot_dependencies` (`dict[str, int] = {}`): Information about other bots that your bot
 uses. This is used to facilitate the Bot Query API.
-- `allow_attachments` (`bool = False`): Whether to allow users to upload attachments to your
+- `allow_attachments` (`bool = True`): Whether to allow users to upload attachments to your
 bot.
 - `introduction_message` (`str = ""`): The introduction message to display to the users of your
 bot.
@@ -482,7 +485,7 @@ images.
 - `enforce_author_role_alternation` (`bool = False`): If enabled, Poe will concatenate messages
 so that they follow role alternation, which is a requirement for certain LLM providers like
 Anthropic.
- - `enable_multi_bot_chat_prompting` (`bool = False`): If enabled, Poe will combine previous bot
+ - `enable_multi_bot_chat_prompting` (`bool = True`): If enabled, Poe will combine previous bot
  messages if there is a multibot context.
 
 
@@ -585,3 +588,6 @@ when using OpenAI function calling.
 - `name` (`str`)
 - `tool_call_id` (`str`)
 - `content` (`str`)
+
+
+

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -588,6 +588,3 @@ when using OpenAI function calling.
 - `name` (`str`)
 - `tool_call_id` (`str`)
 - `content` (`str`)
-
-
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fastapi_poe"
-version = "0.0.60"
+version = "0.0.61"
 authors = [
   { name="Lida Li", email="lli@quora.com" },
   { name="Jelle Zijlstra", email="jelle@quora.com" },

--- a/src/fastapi_poe/client.py
+++ b/src/fastapi_poe/client.py
@@ -31,7 +31,7 @@ from .types import (
 from .types import MetaResponse as MetaMessage
 from .types import PartialResponse as BotMessage
 
-PROTOCOL_VERSION = "1.0"
+PROTOCOL_VERSION = "1.1"
 MESSAGE_LENGTH_LIMIT = 10_000
 
 IDENTIFIER_LENGTH = 32

--- a/src/fastapi_poe/types.py
+++ b/src/fastapi_poe/types.py
@@ -212,9 +212,12 @@ class SettingsResponse(BaseModel):
 
     An object representing your bot's response to a settings object.
     #### Fields:
+    - `response_version` (`int = 1`): Different Poe Protocol versions use different default settings
+    values. When provided, Poe will use the default values for the specified response version.
+    If not provided, Poe will use the default values for response version 0.
     - `server_bot_dependencies` (`dict[str, int] = {}`): Information about other bots that your bot
     uses. This is used to facilitate the Bot Query API.
-    - `allow_attachments` (`bool = False`): Whether to allow users to upload attachments to your
+    - `allow_attachments` (`bool = True`): Whether to allow users to upload attachments to your
     bot.
     - `introduction_message` (`str = ""`): The introduction message to display to the users of your
     bot.
@@ -226,13 +229,14 @@ class SettingsResponse(BaseModel):
     - `enforce_author_role_alternation` (`bool = False`): If enabled, Poe will concatenate messages
     so that they follow role alternation, which is a requirement for certain LLM providers like
     Anthropic.
-     - `enable_multi_bot_chat_prompting` (`bool = False`): If enabled, Poe will combine previous bot
+     - `enable_multi_bot_chat_prompting` (`bool = True`): If enabled, Poe will combine previous bot
      messages if there is a multibot context.
 
     """
 
     model_config = ConfigDict(extra="forbid")
 
+    response_version: Optional[int] = 1
     context_clear_window_secs: Optional[int] = None  # deprecated
     allow_user_context_clear: Optional[bool] = None  # deprecated
     custom_rate_card: Optional[str] = None  # deprecated

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -33,7 +33,7 @@ from sse_starlette import ServerSentEvent
 @pytest.fixture
 def mock_request() -> QueryRequest:
     return QueryRequest(
-        version="1.0",
+        version="1.1",
         type="query",
         query=[ProtocolMessage(role="user", content="Hello, world!")],
         user_id="123",
@@ -636,7 +636,7 @@ def test_sync_bot_settings(mock_httpx_post: Mock) -> None:
     mock_httpx_post.return_value = Mock(status_code=200, text="{}")
     sync_bot_settings("test_bot", access_key="test_access_key", settings={"foo": "bar"})
     mock_httpx_post.assert_called_once_with(
-        "https://api.poe.com/bot/update_settings/test_bot/test_access_key/1.0",
+        "https://api.poe.com/bot/update_settings/test_bot/test_access_key/1.1",
         json={"foo": "bar"},
         headers={"Content-Type": "application/json"},
     )
@@ -644,7 +644,7 @@ def test_sync_bot_settings(mock_httpx_post: Mock) -> None:
 
     sync_bot_settings("test_bot", access_key="test_access_key")
     mock_httpx_post.assert_called_once_with(
-        "https://api.poe.com/bot/fetch_settings/test_bot/test_access_key/1.0",
+        "https://api.poe.com/bot/fetch_settings/test_bot/test_access_key/1.1",
         # TODO: pass headers?
         # headers={"Content-Type": "application/json"},
     )

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,6 +1,13 @@
 import pydantic
 import pytest
-from fastapi_poe.types import CostItem, PartialResponse
+from fastapi_poe.types import CostItem, PartialResponse, SettingsResponse
+
+
+class TestSettingsResponse:
+
+    def test_default_response_version(self) -> None:
+        response = SettingsResponse()
+        assert response.response_version == 1
 
 
 def test_extra_attrs() -> None:


### PR DESCRIPTION
## Description

The default values on SettingsResponse are changing in the next version of the Poe Protocol, and this updates fastapi_poe to use the new version's functionality.

## Changes Made
- Added response_version field to SettingsResponse type
- Assigned response_version a value of 1 unless overridden
- Updated comments on SettingsResponse fields
- Bumped Poe Protocol to 1.1

## Testing Done
- Test scenario 1
- Test scenario 2

## Version
- Updated to version 0.0.61

## Checklist
- [ X ] Tests added
- [ X ] Version bumped
- [ X ] Changes tested locally

I will update the documentation on ReadMe when this is merged in