### PR TITLE
add upload file function to client

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -131,9 +131,7 @@ bot.
 Used to output an attachment in your bot's response.
 
 #### Parameters:
-- `message_id` (`Identifier`): The message id associated with the current QueryRequest
-object. **Important**: This must be the request that is currently being handled by
-get_response. Attempting to attach files to previously handled requests will fail.
+- `message_id` (`Identifier`): The message id associated with the current QueryRequest.
 - `download_url` (`Optional[str] = None`): A url to the file to be attached to the message.
 - `download_filename` (`Optional[str] = None`): A filename to be used when storing the
 downloaded attachment. If not set, the filename from the `download_url` is used.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fastapi_poe"
-version = "0.0.62"
+version = "0.0.63"
 authors = [
   { name="Lida Li", email="lli@quora.com" },
   { name="Jelle Zijlstra", email="jelle@quora.com" },

--- a/src/fastapi_poe/__init__.py
+++ b/src/fastapi_poe/__init__.py
@@ -30,6 +30,7 @@ __all__ = [
     "CostItem",
     "InsufficientFundError",
     "CostRequestError",
+    "upload_file",
 ]
 
 from .base import CostRequestError, InsufficientFundError, PoeBot, make_app, run
@@ -41,6 +42,7 @@ from .client import (
     get_final_response,
     stream_request,
     sync_bot_settings,
+    upload_file,
 )
 from .types import (
     Attachment,

--- a/src/fastapi_poe/base.py
+++ b/src/fastapi_poe/base.py
@@ -26,12 +26,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.types import Message
 from typing_extensions import deprecated, overload
 
-from fastapi_poe.client import (
-    PROTOCOL_VERSION,
-    AttachmentUploadError,
-    sync_bot_settings,
-    upload_file,
-)
+from fastapi_poe.client import PROTOCOL_VERSION, sync_bot_settings, upload_file
 from fastapi_poe.templates import (
     IMAGE_VISION_ATTACHMENT_TEMPLATE,
     TEXT_ATTACHMENT_TEMPLATE,
@@ -432,8 +427,6 @@ class PoeBot:
             base_url=base_url,
         )
 
-        if attachment.url is None or attachment.content_type is None:
-            raise AttachmentUploadError("Failed to upload attachment")
         inline_ref = generate_inline_ref() if is_inline else None
         file_events_to_yield = self._file_events_to_yield.setdefault(message_id, [])
 

--- a/src/fastapi_poe/base.py
+++ b/src/fastapi_poe/base.py
@@ -26,7 +26,12 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.types import Message
 from typing_extensions import deprecated, overload
 
-from fastapi_poe.client import PROTOCOL_VERSION, sync_bot_settings, upload_file
+from fastapi_poe.client import (
+    PROTOCOL_VERSION,
+    AttachmentUploadError,
+    sync_bot_settings,
+    upload_file,
+)
 from fastapi_poe.templates import (
     IMAGE_VISION_ATTACHMENT_TEMPLATE,
     TEXT_ATTACHMENT_TEMPLATE,
@@ -428,7 +433,7 @@ class PoeBot:
         )
 
         if attachment.url is None or attachment.content_type is None:
-            raise RuntimeError("Failed to upload attachment")
+            raise AttachmentUploadError("Failed to upload attachment")
         inline_ref = generate_inline_ref() if is_inline else None
         file_events_to_yield = self._file_events_to_yield.setdefault(message_id, [])
 

--- a/src/fastapi_poe/base.py
+++ b/src/fastapi_poe/base.py
@@ -26,14 +26,13 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.types import Message
 from typing_extensions import deprecated, overload
 
-from fastapi_poe.client import PROTOCOL_VERSION, sync_bot_settings
+from fastapi_poe.client import PROTOCOL_VERSION, sync_bot_settings, upload_file
 from fastapi_poe.templates import (
     IMAGE_VISION_ATTACHMENT_TEMPLATE,
     TEXT_ATTACHMENT_TEMPLATE,
     URL_ATTACHMENT_TEMPLATE,
 )
 from fastapi_poe.types import (
-    AttachmentHttpResponse,
     AttachmentUploadResponse,
     ContentType,
     CostItem,
@@ -57,10 +56,6 @@ POE_API_WEBSERVER_BASE_URL = "https://www.quora.com/poe_api/"
 
 
 class InvalidParameterError(Exception):
-    pass
-
-
-class AttachmentUploadError(Exception):
     pass
 
 
@@ -323,7 +318,7 @@ class PoeBot:
     # This overload leaves access_key as the first argument, but is deprecated.
     @overload
     @deprecated(
-        "The access_key parameter is deprecated. "
+        "The access_key and content_type parameters are deprecated. "
         "Set the access_key when creating the Bot object instead."
     )
     async def post_message_attachment(
@@ -350,7 +345,6 @@ class PoeBot:
         download_filename: Optional[str] = None,
         file_data: Optional[Union[bytes, BinaryIO]] = None,
         filename: Optional[str] = None,
-        content_type: Optional[str] = None,
         is_inline: bool = False,
         base_url: str = POE_API_WEBSERVER_BASE_URL,
     ) -> AttachmentUploadResponse: ...
@@ -373,9 +367,7 @@ class PoeBot:
         Used to output an attachment in your bot's response.
 
         #### Parameters:
-        - `message_id` (`Identifier`): The message id associated with the current QueryRequest
-        object. **Important**: This must be the request that is currently being handled by
-        get_response. Attempting to attach files to previously handled requests will fail.
+        - `message_id` (`Identifier`): The message id associated with the current QueryRequest.
         - `download_url` (`Optional[str] = None`): A url to the file to be attached to the message.
         - `download_filename` (`Optional[str] = None`): A filename to be used when storing the
         downloaded attachment. If not set, the filename from the `download_url` is used.
@@ -391,9 +383,8 @@ class PoeBot:
         `filename`.
 
         """
-        if message_id is None:
-            raise InvalidParameterError("message_id parameter is required")
 
+        assert message_id is not None, "message_id parameter is required"
         name = filename or download_filename
         if not name:
             if not download_url:
@@ -403,53 +394,6 @@ class PoeBot:
             else:
                 name = get_filename_from_url(download_url)
 
-        attachment_http_response = await self._make_file_attachment_request(
-            access_key=access_key,
-            message_id=message_id,
-            download_url=download_url,
-            download_filename=download_filename,
-            file_data=file_data,
-            filename=filename,
-            content_type=content_type,
-            is_inline=is_inline,
-            base_url=base_url,
-        )
-        if (
-            attachment_http_response.attachment_url is None
-            or attachment_http_response.mime_type is None
-        ):
-            raise AttachmentUploadError("Failed to upload attachment")
-        inline_ref = generate_inline_ref() if is_inline else None
-        file_events_to_yield = self._file_events_to_yield.setdefault(message_id, [])
-
-        assert name is not None  # we check this above, but pyright can't detect it
-        file_events_to_yield.append(
-            self.file_event(
-                url=attachment_http_response.attachment_url,
-                content_type=attachment_http_response.mime_type,
-                name=name,
-                inline_ref=inline_ref,
-            )
-        )
-        return AttachmentUploadResponse(
-            attachment_url=attachment_http_response.attachment_url,
-            mime_type=attachment_http_response.mime_type,
-            inline_ref=inline_ref,
-        )
-
-    async def _make_file_attachment_request(
-        self,
-        message_id: Identifier,
-        *,
-        access_key: Optional[str] = None,
-        download_url: Optional[str] = None,
-        download_filename: Optional[str] = None,
-        file_data: Optional[Union[bytes, BinaryIO]] = None,
-        filename: Optional[str] = None,
-        content_type: Optional[str] = None,
-        is_inline: bool = False,
-        base_url: str = POE_API_WEBSERVER_BASE_URL,
-    ) -> AttachmentHttpResponse:
         if self.access_key:
             if access_key:
                 warnings.warn(
@@ -467,57 +411,41 @@ class PoeBot:
                     + " provided with an access_key when make_app is called."
                 )
             attachment_access_key = access_key
-        url = f"{base_url}file_upload_3RD_PARTY_POST"
 
-        async with httpx.AsyncClient(timeout=120) as client:
-            try:
-                headers = {"Authorization": f"{attachment_access_key}"}
-                if download_url:
-                    if file_data or filename:
-                        raise InvalidParameterError(
-                            "Cannot provide filename or file_data if download_url is provided."
-                        )
-                    data = {
-                        "message_id": message_id,
-                        "is_inline": is_inline,
-                        "download_url": download_url,
-                    }
-                    if download_filename:
-                        data["download_filename"] = download_filename
-                    request = httpx.Request("POST", url, data=data, headers=headers)
-                elif file_data and filename:
-                    data = {"message_id": message_id, "is_inline": is_inline}
-                    files = {
-                        "file": (
-                            (filename, file_data)
-                            if content_type is None
-                            else (filename, file_data, content_type)
-                        )
-                    }
-                    request = httpx.Request(
-                        "POST", url, files=files, data=data, headers=headers
-                    )
-                else:
-                    raise InvalidParameterError(
-                        "Must provide either download_url or file_data and filename."
-                    )
-                response = await client.send(request)
+        if content_type is not None:
+            warnings.warn(
+                "content_type parameter is deprecated, and will be removed in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
-                if response.status_code != 200:
-                    error_pieces = [piece async for piece in response.aiter_text()]
-                    raise AttachmentUploadError(
-                        f"{response.status_code} {response.reason_phrase}: {''.join(error_pieces)}"
-                    )
+        attachment = await upload_file(
+            file=file_data,
+            file_url=download_url,
+            file_name=filename or download_filename,
+            api_key=attachment_access_key,
+            base_url=base_url,
+        )
 
-                response_data = response.json()
-                return AttachmentHttpResponse(
-                    mime_type=response_data.get("mime_type"),
-                    attachment_url=response_data.get("attachment_url"),
-                )
+        if attachment.url is None or attachment.content_type is None:
+            raise RuntimeError("Failed to upload attachment")
+        inline_ref = generate_inline_ref() if is_inline else None
+        file_events_to_yield = self._file_events_to_yield.setdefault(message_id, [])
 
-            except httpx.HTTPError:
-                logger.error("An HTTP error occurred when attempting to attach file")
-                raise
+        assert name is not None  # we check this above, but pyright can't detect it
+        file_events_to_yield.append(
+            self.file_event(
+                url=attachment.url,
+                content_type=attachment.content_type,
+                name=name,
+                inline_ref=inline_ref,
+            )
+        )
+        return AttachmentUploadResponse(
+            attachment_url=attachment.url,
+            mime_type=attachment.content_type,
+            inline_ref=inline_ref,
+        )
 
     @deprecated(
         "This method is deprecated. Use `insert_attachment_messages` instead."

--- a/src/fastapi_poe/client.py
+++ b/src/fastapi_poe/client.py
@@ -834,7 +834,7 @@ async def upload_file(
                 raise ValueError(
                     "`file_name` is mandatory when file object has no name attribute."
                 )
-        elif isinstance(file, (bytes, bytearray, memoryview)):
+        elif isinstance(file, (bytes, bytearray)):
             raise ValueError("`file_name` is mandatory when sending raw bytes.")
         else:
             raise ValueError("unsupported file type")

--- a/src/fastapi_poe/client.py
+++ b/src/fastapi_poe/client.py
@@ -868,7 +868,7 @@ async def upload_file(
         if response.status_code != 200:
             # collect full error text (endpoint streams errors)
             try:
-                err_txt = "".join([p async for p in response.aiter_text()])
+                err_txt = await response.aread()
             except Exception:
                 err_txt = response.text
             raise AttachmentUploadError(
@@ -886,8 +886,8 @@ async def upload_file(
         )
 
     # retry wrapper
-    async with httpx.AsyncClient(timeout=120) as owned_session:
-        _sess = session or owned_session
+    _sess = session or httpx.AsyncClient(timeout=120)
+    async with _sess:
         for attempt in range(num_tries):
             try:
                 return await _do_upload(_sess)

--- a/src/fastapi_poe/client.py
+++ b/src/fastapi_poe/client.py
@@ -8,11 +8,13 @@ For more details, see: https://creator.poe.com/docs/server-bots-functional-guide
 import asyncio
 import contextlib
 import inspect
+import io
 import json
+import os
 import warnings
 from collections.abc import AsyncGenerator, Generator
 from dataclasses import dataclass, field
-from typing import Any, Callable, Optional, Union, cast
+from typing import Any, BinaryIO, Callable, Optional, Union, cast
 
 import httpx
 import httpx_sse
@@ -38,6 +40,10 @@ IDENTIFIER_LENGTH = 32
 MAX_EVENT_COUNT = 1000
 
 ErrorHandler = Callable[[Exception, str], None]
+
+
+class AttachmentUploadError(Exception):
+    """Raised when there is an error uploading an attachment."""
 
 
 class BotError(Exception):
@@ -782,3 +788,113 @@ def sync_bot_settings(
             error_message += " Check that the bot server is running."
         raise BotError(error_message) from e
     print(response.text)
+
+
+async def upload_file(
+    file: Optional[Union[bytes, BinaryIO]] = None,
+    file_url: Optional[str] = None,
+    file_name: Optional[str] = None,
+    api_key: str = "",
+    *,
+    session: Optional[httpx.AsyncClient] = None,
+    on_error: ErrorHandler = _default_error_handler,
+    num_tries: int = 2,
+    retry_sleep_time: float = 0.5,
+    base_url: str = "https://www.quora.com/poe_api/",
+) -> Attachment:
+    """
+    Upload a file (raw bytes *or* via URL) to Poe and receive an Attachment
+    object that can be returned directly from a bot or stored for later use.
+
+    #### Parameters:
+    - `file` (`Optional[Union[bytes, BinaryIO]] = None`): The file to upload.
+    - `file_url` (`Optional[str] = None`): The URL of the file to upload.
+    - `file_name` (`Optional[str] = None`): The name of the file to upload. Required if
+    `file` is provided as raw bytes.
+    - `api_key` (`str = ""`): Your Poe API key, available at poe.com/api_key. This can
+    also be the `access_key` if called from a Poe server bot.
+
+    #### Returns:
+    - `Attachment`: An Attachment object representing the uploaded file.
+
+    """
+    if not api_key:
+        raise ValueError(
+            "`api_key` is required (generate one at https://poe.com/api_key)"
+        )
+    if (file is None and file_url is None) or (file and file_url):
+        raise ValueError("Provide either `file` or `file_url`, not both.")
+
+    if file is not None and not file_name:
+        if isinstance(file, io.IOBase):
+            potential = getattr(file, "name", "")
+            if potential:
+                file_name = os.path.basename(potential)
+            if not file_name:
+                raise ValueError(
+                    "`file_name` is mandatory when file object has no name attribute."
+                )
+        elif isinstance(file, (bytes, bytearray, memoryview)):
+            raise ValueError("`file_name` is mandatory when sending raw bytes.")
+        else:
+            raise ValueError("unsupported file type")
+
+    endpoint = base_url.rstrip("/") + "/file_upload_3RD_PARTY_POST"
+
+    async def _do_upload(_session: httpx.AsyncClient) -> Attachment:
+        headers = {"Authorization": api_key}
+
+        if file_url:
+            data: dict[str, str] = {"download_url": file_url}
+            if file_name:
+                data["download_filename"] = file_name
+            request = _session.build_request(
+                "POST", endpoint, data=data, headers=headers
+            )
+        else:  # raw bytes / BinaryIO
+            assert (
+                file is not None
+            ), "file is required if file_url is not provided"  # pyright
+            file_data = (
+                file.read() if not isinstance(file, (bytes, bytearray)) else file
+            )
+            files = {"file": (file_name, file_data)}
+            request = _session.build_request(
+                "POST", endpoint, files=files, headers=headers
+            )
+
+        response = await _session.send(request)
+
+        if response.status_code != 200:
+            # collect full error text (endpoint streams errors)
+            try:
+                err_txt = "".join([p async for p in response.aiter_text()])
+            except Exception:
+                err_txt = response.text
+            raise AttachmentUploadError(
+                f"{response.status_code} {response.reason_phrase}: {err_txt}"
+            )
+
+        data = response.json()
+        if not {"attachment_url", "mime_type"}.issubset(data):
+            raise AttachmentUploadError(f"Unexpected response format: {data}")
+
+        return Attachment(
+            url=data["attachment_url"],
+            content_type=data["mime_type"],
+            name=file_name or "file",
+        )
+
+    # retry wrapper
+    async with httpx.AsyncClient(timeout=120) as owned_session:
+        _sess = session or owned_session
+        for attempt in range(num_tries):
+            try:
+                return await _do_upload(_sess)
+            except Exception as e:
+                on_error(e, f"upload attempt {attempt+1}/{num_tries} failed")
+                if attempt == num_tries - 1:
+                    raise
+                await asyncio.sleep(retry_sleep_time)
+
+    raise AssertionError("retries exhausted")  # unreachable, but satisfies pyright

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -7,14 +7,8 @@ from unittest.mock import AsyncMock, Mock, patch
 import httpx
 import pytest
 from fastapi import Request
-from fastapi_poe.base import (
-    AttachmentUploadError,
-    CostRequestError,
-    InsufficientFundError,
-    InvalidParameterError,
-    PoeBot,
-    make_app,
-)
+from fastapi_poe.base import CostRequestError, InsufficientFundError, PoeBot, make_app
+from fastapi_poe.client import AttachmentUploadError
 from fastapi_poe.templates import (
     IMAGE_VISION_ATTACHMENT_TEMPLATE,
     TEXT_ATTACHMENT_TEMPLATE,
@@ -492,7 +486,7 @@ class TestPoeBot:
                 download_filename="test.txt",
             )
 
-        with pytest.raises(InvalidParameterError):
+        with pytest.raises(ValueError):
             await basic_bot.post_message_attachment(
                 message_id="123",
                 download_url="https://pfst.cf2.poecdn.net/base/text/test.txt",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,5 @@
 import json
-from collections.abc import AsyncGenerator, AsyncIterator
+from collections.abc import AsyncGenerator, AsyncIterator, Awaitable
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from typing import Any, Callable, cast
 from unittest.mock import AsyncMock, Mock, patch
@@ -8,6 +8,7 @@ import httpx
 import pytest
 import pytest_asyncio
 from fastapi_poe.client import (
+    AttachmentUploadError,
     BotError,
     BotErrorNoRetry,
     _BotContext,
@@ -660,63 +661,101 @@ def test_sync_bot_settings(mock_httpx_post: Mock) -> None:
         sync_bot_settings("test_bot", access_key="test_access_key")
 
 
-@pytest.mark.asyncio
-async def test_upload_file() -> None:
+def _make_mock_async_client(
+    fake_send: Callable[[httpx.Request], Awaitable[httpx.Response]]
+) -> httpx.AsyncClient:
     """
-    Verifies that:
-      • `upload_file` returns a correctly-populated `Attachment`
-      • No real network request is made
-      • The correct request payload is built (download_url /
-        download_filename)
-    """
+    Builds an `httpx.AsyncClient` double whose `send` coroutine is supplied
+    by the caller (`fake_send`).
 
-    expected_json: dict[str, Any] = {
+    """
+    client = AsyncMock(spec=httpx.AsyncClient)
+
+    client.__aenter__.return_value = client
+    client.__aexit__.return_value = None
+
+    client.build_request = Mock(
+        side_effect=lambda *args, **kwargs: httpx.Request(*args, **kwargs)
+    )
+    client.send = AsyncMock(side_effect=fake_send)
+
+    return client
+
+
+@pytest.mark.asyncio
+async def test_upload_file_via_url() -> None:
+    expected_json = {
         "attachment_url": "https://cdn.example.com/fake-id/file.txt",
         "mime_type": "text/plain",
     }
-    captured_request: dict[str, httpx.Request] = {}
+    captured: dict[str, httpx.Request] = {}
 
     async def fake_send(request: httpx.Request) -> httpx.Response:
-        """
-        It stores the request object so we can assert on it later,
-        and returns a canned 200 response with `expected_json`.
-        """
-        captured_request["request"] = request
+        captured["request"] = request
         return httpx.Response(
             status_code=200,
             content=json.dumps(expected_json).encode(),
             headers={"content-type": "application/json"},
         )
 
-    with patch("httpx.AsyncClient") as mock_async_client:
-        # Create a mock client instance
-        mock_client_instance = AsyncMock()
-
-        # Properly mock the context manager
-        mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
-        mock_client_instance.__aexit__ = AsyncMock(return_value=None)
-
-        # Mock the methods
-        mock_client_instance.build_request = Mock(
-            side_effect=lambda *args, **kwargs: httpx.Request(*args, **kwargs)
-        )
-        mock_client_instance.send = AsyncMock(side_effect=fake_send)
-
-        mock_async_client.return_value = mock_client_instance
-
+    with patch("httpx.AsyncClient", return_value=_make_mock_async_client(fake_send)):
         attachment = await upload_file(
             file_url="https://example.com/file.txt",
             file_name="file.txt",
             api_key="secret-key",
         )
 
-        # 1. The function returned the correct Attachment instance
-        assert attachment.url == expected_json["attachment_url"]
-        assert attachment.content_type == expected_json["mime_type"]
-        assert attachment.name == "file.txt"
+    # Attachment object
+    assert attachment.url == expected_json["attachment_url"]
+    assert attachment.content_type == expected_json["mime_type"]
+    assert attachment.name == "file.txt"
 
-        # 2. It built the expected HTTP request
-        request = captured_request["request"]
-        assert request.url.path.endswith("/file_upload_3RD_PARTY_POST")
-        assert request.method == "POST"
-        assert request.headers["Authorization"] == "secret-key"
+    # HTTP request
+    req = captured["request"]
+    assert req.url.path.endswith("/file_upload_3RD_PARTY_POST")
+    assert req.method == "POST"
+    assert req.headers["Authorization"] == "secret-key"
+
+
+@pytest.mark.asyncio
+async def test_upload_file_raw_bytes() -> None:
+    expected_json = {
+        "attachment_url": "https://cdn.example.com/fake-id/hello.txt",
+        "mime_type": "text/plain",
+    }
+    captured: dict[str, httpx.Request] = {}
+
+    async def fake_send(request: httpx.Request) -> httpx.Response:
+        captured["request"] = request
+        return httpx.Response(
+            status_code=200,
+            content=json.dumps(expected_json).encode(),
+            headers={"content-type": "application/json"},
+        )
+
+    with patch("httpx.AsyncClient", return_value=_make_mock_async_client(fake_send)):
+        attachment = await upload_file(
+            file=b"hello world", file_name="hello.txt", api_key="secret-key"
+        )
+
+    # Attachment object
+    assert attachment.url == expected_json["attachment_url"]
+    assert attachment.content_type == expected_json["mime_type"]
+    assert attachment.name == "hello.txt"
+
+    # HTTP request
+    req = captured["request"]
+    assert req.headers["Authorization"] == "secret-key"
+    assert req.headers["Content-Type"].startswith("multipart/form-data")
+
+
+@pytest.mark.asyncio
+async def test_upload_file_error_raises() -> None:
+    async def fake_send(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(status_code=500, content=b"internal error")
+
+    with (
+        patch("httpx.AsyncClient", return_value=_make_mock_async_client(fake_send)),
+        pytest.raises(AttachmentUploadError),
+    ):
+        await upload_file(file_url="https://example.com/file.txt", api_key="secret-key")


### PR DESCRIPTION
Add a file upload function to client. This should enable file input for bot query requests.

This will be used like:
`fp.upload_file(file=open("test.txt", "rb"), api_key=k)`

The same `upload_file` function is also used in `post_message_attachment` which is used in `PoeBot` to send file output.