### PR TITLE
client: add extra_headers to stream_request()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fastapi_poe"
-version = "0.0.63"
+version = "0.0.64"
 authors = [
   { name="Lida Li", email="lli@quora.com" },
   { name="Jelle Zijlstra", email="jelle@quora.com" },

--- a/src/fastapi_poe/client.py
+++ b/src/fastapi_poe/client.py
@@ -74,13 +74,15 @@ class _BotContext:
     session: httpx.AsyncClient = field(repr=False)
     api_key: Optional[str] = field(default=None, repr=False)
     on_error: Optional[ErrorHandler] = field(default=None, repr=False)
-    default_headers: dict[str, str] = field(default_factory=dict, repr=False)
+    extra_headers: Optional[dict[str, str]] = field(default=None, repr=False)
 
     @property
     def headers(self) -> dict[str, str]:
-        headers = {**self.default_headers, "Accept": "application/json"}
+        headers = {"Accept": "application/json"}
         if self.api_key is not None:
             headers["Authorization"] = f"Bearer {self.api_key}"
+        if self.extra_headers is not None:
+            headers.update(self.extra_headers)
         return headers
 
     async def report_error(
@@ -355,7 +357,7 @@ async def stream_request(
     num_tries: int = 2,
     retry_sleep_time: float = 0.5,
     base_url: str = "https://api.poe.com/bot/",
-    extra_headers: dict[str, str] = {},
+    extra_headers: Optional[dict[str, str]] = None,
 ) -> AsyncGenerator[BotMessage, None]:
     """
 
@@ -460,7 +462,7 @@ async def _stream_request_with_tools(
     num_tries: int = 2,
     retry_sleep_time: float = 0.5,
     base_url: str = "https://api.poe.com/bot/",
-    extra_headers: dict[str, str] = {},
+    extra_headers: Optional[dict[str, str]] = None,
 ) -> AsyncGenerator[Union[BotMessage, ToolCallDefinition], None]:
     tool_call_object_dict: dict[int, dict[str, Any]] = {}
     async for message in stream_request_base(
@@ -526,7 +528,7 @@ async def stream_request_base(
     num_tries: int = 2,
     retry_sleep_time: float = 0.5,
     base_url: str = "https://api.poe.com/bot/",
-    extra_headers: dict[str, str] = {},
+    extra_headers: Optional[dict[str, str]] = None,
 ) -> AsyncGenerator[BotMessage, None]:
     if access_key != "":
         warnings.warn(
@@ -544,7 +546,7 @@ async def stream_request_base(
             api_key=api_key,
             session=session,
             on_error=on_error,
-            default_headers=extra_headers,
+            extra_headers=extra_headers,
         )
         got_response = False
         for i in range(num_tries):

--- a/src/fastapi_poe/client.py
+++ b/src/fastapi_poe/client.py
@@ -74,10 +74,11 @@ class _BotContext:
     session: httpx.AsyncClient = field(repr=False)
     api_key: Optional[str] = field(default=None, repr=False)
     on_error: Optional[ErrorHandler] = field(default=None, repr=False)
+    default_headers: dict[str, str] = field(default_factory=dict, repr=False)
 
     @property
     def headers(self) -> dict[str, str]:
-        headers = {"Accept": "application/json"}
+        headers = {**self.default_headers, "Accept": "application/json"}
         if self.api_key is not None:
             headers["Authorization"] = f"Bearer {self.api_key}"
         return headers
@@ -354,6 +355,7 @@ async def stream_request(
     num_tries: int = 2,
     retry_sleep_time: float = 0.5,
     base_url: str = "https://api.poe.com/bot/",
+    extra_headers: dict[str, str] = {},
 ) -> AsyncGenerator[BotMessage, None]:
     """
 
@@ -391,6 +393,7 @@ async def stream_request(
             num_tries=num_tries,
             retry_sleep_time=retry_sleep_time,
             base_url=base_url,
+            extra_headers=extra_headers,
         ):
             if isinstance(message, ToolCallDefinition):
                 tool_calls.append(message)
@@ -412,6 +415,7 @@ async def stream_request(
             num_tries=num_tries,
             retry_sleep_time=retry_sleep_time,
             base_url=base_url,
+            extra_headers=extra_headers,
         ):
             yield message
 
@@ -456,6 +460,7 @@ async def _stream_request_with_tools(
     num_tries: int = 2,
     retry_sleep_time: float = 0.5,
     base_url: str = "https://api.poe.com/bot/",
+    extra_headers: dict[str, str] = {},
 ) -> AsyncGenerator[Union[BotMessage, ToolCallDefinition], None]:
     tool_call_object_dict: dict[int, dict[str, Any]] = {}
     async for message in stream_request_base(
@@ -470,6 +475,7 @@ async def _stream_request_with_tools(
         num_tries=num_tries,
         retry_sleep_time=retry_sleep_time,
         base_url=base_url,
+        extra_headers=extra_headers,
     ):
         # OpenAI might return empty choices when its sending the final usage chunk
         if (
@@ -520,6 +526,7 @@ async def stream_request_base(
     num_tries: int = 2,
     retry_sleep_time: float = 0.5,
     base_url: str = "https://api.poe.com/bot/",
+    extra_headers: dict[str, str] = {},
 ) -> AsyncGenerator[BotMessage, None]:
     if access_key != "":
         warnings.warn(
@@ -533,7 +540,11 @@ async def stream_request_base(
             session = await stack.enter_async_context(httpx.AsyncClient(timeout=600))
         url = f"{base_url}{bot_name}"
         ctx = _BotContext(
-            endpoint=url, api_key=api_key, session=session, on_error=on_error
+            endpoint=url,
+            api_key=api_key,
+            session=session,
+            on_error=on_error,
+            default_headers=extra_headers,
         )
         got_response = False
         for i in range(num_tries):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -717,7 +717,7 @@ def test_sync_bot_settings(mock_httpx_post: Mock) -> None:
 
 
 def _make_mock_async_client(
-    fake_send: Callable[[httpx.Request], Awaitable[httpx.Response]],
+    fake_send: Callable[[httpx.Request], Awaitable[httpx.Response]]
 ) -> httpx.AsyncClient:
     """
     Builds an `httpx.AsyncClient` double whose `send` coroutine is supplied

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -705,7 +705,7 @@ def test_sync_bot_settings(mock_httpx_post: Mock) -> None:
 
 
 def _make_mock_async_client(
-    fake_send: Callable[[httpx.Request], Awaitable[httpx.Response]],
+    fake_send: Callable[[httpx.Request], Awaitable[httpx.Response]]
 ) -> httpx.AsyncClient:
     """
     Builds an `httpx.AsyncClient` double whose `send` coroutine is supplied

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,7 +2,7 @@ import json
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from typing import Any, Callable, cast
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import ANY, AsyncMock, Mock, patch
 
 import httpx
 import pytest
@@ -259,6 +259,23 @@ class TestStreamRequest:
             concatenated_text += message.text
         assert concatenated_text == "Hello, world!"
 
+    @patch("fastapi_poe.client._BotContext")
+    async def test_stream_request_with_extra_headers(
+        self, mock_bot_context: Mock, mock_request: QueryRequest
+    ) -> None:
+        async for _ in stream_request(
+            mock_request, "test_bot", extra_headers={"X-Test": "test"}
+        ):
+            pass
+
+        mock_bot_context.assert_called_once_with(
+            endpoint=ANY,
+            session=ANY,
+            api_key=ANY,
+            on_error=ANY,
+            default_headers={"X-Test": "test"},
+        )
+
     @patch("fastapi_poe.client._BotContext.perform_query_request")
     async def test_stream_request_with_tools(
         self,
@@ -370,6 +387,32 @@ class Test_BotContext:
             yield mock_source
 
         return asynccontextmanager(mock_sse_connection)
+
+    def test_headers(self) -> None:
+        assert _BotContext(endpoint="test_endpoint", session=AsyncMock()).headers == {
+            "Accept": "application/json"
+        }
+
+        # API key added as auth header
+        assert _BotContext(
+            endpoint="test_endpoint", session=AsyncMock(), api_key="test_api_key"
+        ).headers == {
+            "Accept": "application/json",
+            "Authorization": "Bearer test_api_key",
+        }
+
+        # Custom default headers
+        bot_context = _BotContext(
+            endpoint="test_endpoint",
+            session=AsyncMock(),
+            api_key="test_api_key",
+            default_headers={"X-Test": "test"},
+        )
+        assert bot_context.headers == {
+            "X-Test": "test",
+            "Accept": "application/json",
+            "Authorization": "Bearer test_api_key",
+        }
 
     async def test_perform_query_request_basic(
         self, mock_bot_context: _BotContext, mock_request: QueryRequest
@@ -662,7 +705,7 @@ def test_sync_bot_settings(mock_httpx_post: Mock) -> None:
 
 
 def _make_mock_async_client(
-    fake_send: Callable[[httpx.Request], Awaitable[httpx.Response]]
+    fake_send: Callable[[httpx.Request], Awaitable[httpx.Response]],
 ) -> httpx.AsyncClient:
     """
     Builds an `httpx.AsyncClient` double whose `send` coroutine is supplied


### PR DESCRIPTION
## Description
Added extra_headers as an optional param on stream_request() to allow passing custom headers

## Changes Made
- Added extra_headers

## Testing Done
- Added unit tests to cover the updated headers building logic

## Version
- Updated to version 0.0.64

## Breaking Changes
- N/A

## Checklist
- [x] Tests added
- [ ] Documentation updated
- [x] Version bumped
- [x] Changes tested locally