### PR TITLE
monetization: ceil floats passed to CostItem.amount_usd_milli_cents

### DIFF
--- a/src/fastapi_poe/types.py
+++ b/src/fastapi_poe/types.py
@@ -1,3 +1,4 @@
+import math
 from typing import Any, Optional, Union
 
 from fastapi import Request
@@ -41,6 +42,8 @@ class CostItem(BaseModel):
 
     @field_validator("amount_usd_milli_cents", mode="before")
     def validate_amount_is_int(cls, v: Union[int, str, float]) -> int:
+        if isinstance(v, float):
+            return math.ceil(v)
         if not isinstance(v, int):
             raise ValueError(
                 "Invalid amount: expected an integer for amount_usd_milli_cents, "

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -21,14 +21,12 @@ def test_extra_attrs() -> None:
 
 def test_cost_item() -> None:
     with pytest.raises(pydantic.ValidationError):
-        CostItem(amount_usd_milli_cents=1.5)  # type: ignore
-
-    with pytest.raises(pydantic.ValidationError):
         CostItem(amount_usd_milli_cents="1")  # type: ignore
-
-    with pytest.raises(pydantic.ValidationError):
-        CostItem(amount_usd_milli_cents=-2.5)  # type: ignore
 
     item = CostItem(amount_usd_milli_cents=25)
     assert item.amount_usd_milli_cents == 25
     assert item.description is None
+
+    item = CostItem(amount_usd_milli_cents=25.5, description="Test")  # type: ignore
+    assert item.amount_usd_milli_cents == 26
+    assert item.description == "Test"


### PR DESCRIPTION
- use math.ceil to implicitly round up amounts provided as floats to integers instead of throwing an error