### PR TITLE
Bugfix/fix file yielding

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -562,10 +562,12 @@ Request parameters for a report_error request.
 
 Attachment included in a protocol message.
 #### Fields:
-- `url` (`str`)
-- `content_type` (`str`)
-- `name` (`str`)
-- `parsed_content` (`Optional[str] = None`)
+- `url` (`str`): The download URL of the attachment.
+- `content_type` (`str`): The MIME type of the attachment.
+- `name` (`str`): The name of the attachment.
+- `inline_ref` (`Optional[str] = None`): Set this to make Poe render the attachment inline.
+    You can then reference the attachment inline using ![title][inline_ref].
+- `parsed_content` (`Optional[str] = None`): The parsed content of the attachment.
 
 
 

--- a/src/fastapi_poe/base.py
+++ b/src/fastapi_poe/base.py
@@ -852,23 +852,11 @@ class PoeBot:
 
                 if isinstance(event, PartialResponse) and event.attachment:
                     attachment = event.attachment
-                    inline_ref = attachment.inline_ref
-                    if "poecdn" not in attachment.url:
-                        # the file must be hosted on Poe for attachment
-                        if not self.access_key:
-                            raise ValueError(
-                                "access_key must be set on the bot to make file attachments"
-                            )
-                        attachment = await upload_file(
-                            file_url=attachment.url,
-                            file_name=attachment.name,
-                            api_key=self.access_key,
-                        )
                     yield self.file_event(
                         url=attachment.url,
                         content_type=attachment.content_type,
                         name=attachment.name,
-                        inline_ref=inline_ref,
+                        inline_ref=attachment.inline_ref,
                     )
 
                 if isinstance(event, ServerSentEvent):

--- a/src/fastapi_poe/base.py
+++ b/src/fastapi_poe/base.py
@@ -849,6 +849,28 @@ class PoeBot:
                     request.message_id
                 ):
                     yield pending_file_event
+
+                if isinstance(event, PartialResponse) and event.attachment:
+                    attachment = event.attachment
+                    inline_ref = attachment.inline_ref
+                    if "poecdn" not in attachment.url:
+                        # the file must be hosted on Poe for attachment
+                        if not self.access_key:
+                            raise ValueError(
+                                "access_key must be set on the bot to make file attachments"
+                            )
+                        attachment = await upload_file(
+                            file_url=attachment.url,
+                            file_name=attachment.name,
+                            api_key=self.access_key,
+                        )
+                    yield self.file_event(
+                        url=attachment.url,
+                        content_type=attachment.content_type,
+                        name=attachment.name,
+                        inline_ref=inline_ref,
+                    )
+
                 if isinstance(event, ServerSentEvent):
                     yield event
                 elif isinstance(event, ErrorResponse):
@@ -873,6 +895,7 @@ class PoeBot:
                     yield self.replace_response_event(event.text)
                 else:
                     yield self.text_event(event.text)
+
             # yield any remaining file events
             async for pending_file_event in self._yield_pending_file_events(
                 request.message_id

--- a/src/fastapi_poe/client.py
+++ b/src/fastapi_poe/client.py
@@ -213,6 +213,9 @@ class _BotContext:
                             name=await self._get_single_json_field(
                                 event.data, "file", message_id, "name"
                             ),
+                            inline_ref=await self._get_single_json_field(
+                                event.data, "file", message_id, "inline_ref"
+                            ),
                         ),
                     )
                     continue

--- a/src/fastapi_poe/types.py
+++ b/src/fastapi_poe/types.py
@@ -59,16 +59,19 @@ class Attachment(BaseModel):
 
     Attachment included in a protocol message.
     #### Fields:
-    - `url` (`str`)
-    - `content_type` (`str`)
-    - `name` (`str`)
-    - `parsed_content` (`Optional[str] = None`)
+    - `url` (`str`): The download URL of the attachment.
+    - `content_type` (`str`): The MIME type of the attachment.
+    - `name` (`str`): The name of the attachment.
+    - `inline_ref` (`Optional[str] = None`): Set this to make Poe render the attachment inline.
+        You can then reference the attachment inline using ![title][inline_ref].
+    - `parsed_content` (`Optional[str] = None`): The parsed content of the attachment.
 
     """
 
     url: str
     content_type: str
     name: str
+    inline_ref: Optional[str] = None
     parsed_content: Optional[str] = None
 
 


### PR DESCRIPTION
Previously, to attach a file to the bot's output, we required the bot to call `post_message_attachment()`. This 1) was confusing to creators and 2) made forwarding a bot's output more complicated. 

Now a bot can do something like:

`yield fp.PartialResponse(text=f"![leopard][{inline_ref}]", attachment=fp.Attachment(url=IMAGE_URL, content_type="image/jpeg", name="leopard.jpeg", inline_ref=inline_ref))`

to make a file attachment.