### PR TITLE
Handle SSE's index field

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fastapi_poe"
-version = "0.0.69"
+version = "0.0.70"
 authors = [
   { name="Lida Li", email="lli@quora.com" },
   { name="Jelle Zijlstra", email="jelle@quora.com" },

--- a/src/fastapi_poe/client.py
+++ b/src/fastapi_poe/client.py
@@ -340,7 +340,7 @@ class _BotContext:
         result = data_dict[field]
         if not isinstance(result, int):
             return None
-        return data_dict[field]
+        return result
 
     async def _load_json_dict(
         self, data: str, context: str, message_id: Identifier

--- a/src/fastapi_poe/client.py
+++ b/src/fastapi_poe/client.py
@@ -184,7 +184,7 @@ class _BotContext:
         ) as event_source:
             async for event in event_source.aiter_sse():
                 event_count += 1
-                index: Optional[int] = await self._get_single_json_field_safe(
+                index: Optional[int] = await self._get_single_json_integer_field_safe(
                     event.data, event.event, message_id, "index"
                 )
                 if event.event == "done":
@@ -331,11 +331,14 @@ class _BotContext:
             raise BotErrorNoRetry(f"Expected string in '{context}' event")
         return text
 
-    async def _get_single_json_field_safe(
-        self, data: str, context: str, message_id: Identifier, field: str = "text"
-    ) -> Optional[Any]:
+    async def _get_single_json_integer_field_safe(
+        self, data: str, context: str, message_id: Identifier, field: str
+    ) -> Optional[int]:
         data_dict = await self._load_json_dict(data, context, message_id)
         if field not in data_dict:
+            return None
+        result = data_dict[field]
+        if not isinstance(result, int):
             return None
         return data_dict[field]
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -774,6 +774,8 @@ class Test_BotContext:
             ServerSentEvent(event="text", data='{"text": "hello", "index": 0}'),
             ServerSentEvent(event="text", data='{"text": " world", "index": 0}'),
             ServerSentEvent(event="text", data='{"text": "hi.", "index": 1}'),
+            # Bad index value should be ignored
+            ServerSentEvent(event="text", data='{"text": "text with bad index", "index": "banana"}'),
             ServerSentEvent(event="done", data="{}"),
             ServerSentEvent(
                 event="text", data='{"text": "blahblah", "index": 2}'
@@ -817,6 +819,16 @@ class Test_BotContext:
                     full_prompt=repr(mock_request),
                     is_replace_response=False,
                     index=1,
+                ),
+                BotMessage(
+                    text="text with bad index",
+                    raw_response={
+                        "type": "text",
+                        "text": '{"text": "text with bad index", "index": "banana"}',
+                    },
+                    full_prompt=repr(mock_request),
+                    is_replace_response=False,
+                    index=None,
                 ),
             ]
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -775,7 +775,9 @@ class Test_BotContext:
             ServerSentEvent(event="text", data='{"text": " world", "index": 0}'),
             ServerSentEvent(event="text", data='{"text": "hi.", "index": 1}'),
             # Bad index value should be ignored
-            ServerSentEvent(event="text", data='{"text": "text with bad index", "index": "banana"}'),
+            ServerSentEvent(
+                event="text", data='{"text": "text with bad index", "index": "banana"}'
+            ),
             ServerSentEvent(event="done", data="{}"),
             ServerSentEvent(
                 event="text", data='{"text": "blahblah", "index": 2}'

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -626,10 +626,9 @@ class Test_BotContext:
             "Authorization": "Bearer test_api_key",
         }
 
-    async def test_perform_query_request_basic(
+    async def test_perform_query_request_text_events(
         self, mock_bot_context: _BotContext, mock_request: QueryRequest
     ) -> None:
-        # basic text case
         events = [
             ServerSentEvent(event="text", data='{"text": "some"}'),
             ServerSentEvent(event="text", data='{"text": " response."}'),
@@ -647,6 +646,9 @@ class Test_BotContext:
                 concatenated_text += message.text
             assert concatenated_text == "some response."
 
+    async def test_perform_query_request_non_text_events(
+        self, mock_bot_context: _BotContext, mock_request: QueryRequest
+    ) -> None:
         # other events
         events = [
             ServerSentEvent(
@@ -719,7 +721,9 @@ class Test_BotContext:
                 ),
             ]
 
-        # no done event - should still work
+    async def test_perform_query_request_no_done_event_still_succeeds(
+        self, mock_bot_context: _BotContext, mock_request: QueryRequest
+    ) -> None:
         events = [
             ServerSentEvent(event="text", data='{"text": "some"}'),
             ServerSentEvent(event="text", data='{"text": " response."}'),
@@ -733,7 +737,9 @@ class Test_BotContext:
                 concatenated_text += message.text
             assert concatenated_text == "some response."
 
-        # error with allow_retry=false
+    async def test_perform_query_request_error_with_allow_retry_false(
+        self, mock_bot_context: _BotContext, mock_request: QueryRequest
+    ) -> None:
         events = [
             ServerSentEvent(event="text", data='{"text": "some"}'),
             ServerSentEvent(event="error", data='{"allow_retry": false}'),
@@ -746,7 +752,9 @@ class Test_BotContext:
                 ):
                     pass
 
-        # error with allow_retry=true
+    async def test_perform_query_request_error_with_allow_retry_true(
+        self, mock_bot_context: _BotContext, mock_request: QueryRequest
+    ) -> None:
         events = [
             ServerSentEvent(event="text", data='{"text": "some"}'),
             ServerSentEvent(event="error", data='{"allow_retry": true}'),
@@ -758,6 +766,136 @@ class Test_BotContext:
                     request=mock_request, tools=None, tool_calls=None, tool_results=None
                 ):
                     pass
+
+    async def test_perform_query_request_text_events_with_index(
+        self, mock_bot_context: _BotContext, mock_request: QueryRequest
+    ) -> None:
+        events = [
+            ServerSentEvent(event="text", data='{"text": "hello", "index": 0}'),
+            ServerSentEvent(event="text", data='{"text": " world", "index": 0}'),
+            ServerSentEvent(event="text", data='{"text": "hi.", "index": 1}'),
+            ServerSentEvent(event="done", data="{}"),
+            ServerSentEvent(
+                event="text", data='{"text": "blahblah", "index": 2}'
+            ),  # after done; ignored
+        ]
+        with patch("httpx_sse.aconnect_sse") as mock_connect_sse:
+            mock_connect_sse.side_effect = self.create_sse_mock(events)
+            messages = []
+            async for message in mock_bot_context.perform_query_request(
+                request=mock_request, tools=None, tool_calls=None, tool_results=None
+            ):
+                messages.append(message)
+
+            assert messages == [
+                BotMessage(
+                    text="hello",
+                    raw_response={
+                        "type": "text",
+                        "text": '{"text": "hello", "index": 0}',
+                    },
+                    full_prompt=repr(mock_request),
+                    is_replace_response=False,
+                    index=0,
+                ),
+                BotMessage(
+                    text=" world",
+                    raw_response={
+                        "type": "text",
+                        "text": '{"text": " world", "index": 0}',
+                    },
+                    full_prompt=repr(mock_request),
+                    is_replace_response=False,
+                    index=0,
+                ),
+                BotMessage(
+                    text="hi.",
+                    raw_response={
+                        "type": "text",
+                        "text": '{"text": "hi.", "index": 1}',
+                    },
+                    full_prompt=repr(mock_request),
+                    is_replace_response=False,
+                    index=1,
+                ),
+            ]
+
+    async def test_perform_query_request_non_text_events_with_index(
+        self, mock_bot_context: _BotContext, mock_request: QueryRequest
+    ) -> None:
+        # other events
+        events = [
+            ServerSentEvent(event="text", data='{"text": "first", "index": 0}'),
+            ServerSentEvent(
+                event="text", data='{"text": "second message", "index": 1}'
+            ),
+            ServerSentEvent(
+                event="replace_response", data='{"text": " message.", "index": 0}'
+            ),
+            ServerSentEvent(
+                event="suggested_reply",
+                data='{"text": "what do you mean?", "index": 1}',
+            ),
+            ServerSentEvent(event="json", data='{"fruit": "apple", "index": 1}'),
+            ServerSentEvent(event="ping", data='{"index": 1}'),
+            ServerSentEvent(event="done", data='{"index": 1}'),
+        ]
+        with patch("httpx_sse.aconnect_sse") as mock_connect_sse:
+            mock_connect_sse.side_effect = self.create_sse_mock(events)
+            messages = []
+            async for message in mock_bot_context.perform_query_request(
+                request=mock_request, tools=None, tool_calls=None, tool_results=None
+            ):
+                messages.append(message)
+
+            assert messages == [
+                BotMessage(
+                    text="first",
+                    raw_response={
+                        "type": "text",
+                        "text": '{"text": "first", "index": 0}',
+                    },
+                    full_prompt=repr(mock_request),
+                    is_replace_response=False,
+                    index=0,
+                ),
+                BotMessage(
+                    text="second message",
+                    raw_response={
+                        "type": "text",
+                        "text": '{"text": "second message", "index": 1}',
+                    },
+                    full_prompt=repr(mock_request),
+                    is_replace_response=False,
+                    index=1,
+                ),
+                BotMessage(
+                    text=" message.",
+                    raw_response={
+                        "type": "replace_response",
+                        "text": '{"text": " message.", "index": 0}',
+                    },
+                    full_prompt=repr(mock_request),
+                    is_replace_response=True,
+                    index=0,
+                ),
+                BotMessage(
+                    text="what do you mean?",
+                    raw_response={
+                        "type": "suggested_reply",
+                        "text": '{"text": "what do you mean?", "index": 1}',
+                    },
+                    full_prompt=repr(mock_request),
+                    is_suggested_reply=True,
+                    index=1,
+                ),
+                BotMessage(
+                    text="",
+                    full_prompt=repr(mock_request),
+                    data={"fruit": "apple", "index": 1},
+                    index=1,
+                ),
+            ]
 
     @pytest.mark.parametrize(
         "events",


### PR DESCRIPTION
## Description
Parse the Server Sent Event's index field (if any) and convert it to `PartialResponse.index`.

## Changes Made
- Parse the Server Sent Event's index field (if any) and convert it to `PartialResponse.index`.

## Testing Done
- Unit tests for the different kinds of SSEs that may have the index field.

## Version
- Updated to version 0.0.70

## Breaking Changes
- N/A

## Checklist
- [x] Tests added
- [ ] Documentation updated
- [x] Version bumped
- [ ] Changes tested locally