### PR TITLE
Rename CustomToolCallDefinition to CustomCallDefinition and make CustomToolDefinition fields optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fastapi_poe"
-version = "0.0.80"
+version = "0.0.81"
 authors = [
   { name="Yusheng Ding", email="yding@quora.com" },
   { name="Kris Yang", email="kryang@quora.com" },

--- a/src/fastapi_poe/types.py
+++ b/src/fastapi_poe/types.py
@@ -223,11 +223,16 @@ class ToolDefinition(BaseModel):
 
 
 class CustomToolDefinition(BaseModel):
-    """Custom tool definition for OpenAI-compatible custom tools."""
+    """Custom tool definition for OpenAI-compatible custom tools.
+
+    Corresponds to `chat_completion_custom_tool_param.Custom` but
+    with a looser format specification.
+
+    """
 
     name: str
-    description: str
-    format_: dict[str, Any] = Field(alias="format")
+    description: Optional[str] = None
+    format_: Optional[dict[str, Any]] = Field(default=None, alias="format")
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -263,8 +268,12 @@ class ToolCallDefinition(BaseModel):
     function: FunctionCallDefinition
 
 
-class CustomToolCallDefinition(BaseModel):
-    """Custom tool call in model response."""
+class CustomCallDefinition(BaseModel):
+    """Custom tool call in model response.
+
+    Corresponds to `chat_completion_message_custom_tool_call.Custom`.
+
+    """
 
     name: str
     input_: str = Field(alias="input")


### PR DESCRIPTION
- Rename CustomToolCallDefinition to CustomCallDefinition for brevity and consistency
- Make description and format_ fields optional in CustomToolDefinition
- Update all tests to reflect the renaming and optional field changes
- Add tests for optional fields and partial initialization