### PR TITLE
Fix: Preserve index field in tool call responses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fastapi_poe"
-version = "0.0.81"
+version = "0.0.82"
 authors = [
   { name="Yusheng Ding", email="yding@quora.com" },
   { name="Kris Yang", email="kryang@quora.com" },

--- a/src/fastapi_poe/client.py
+++ b/src/fastapi_poe/client.py
@@ -534,7 +534,9 @@ async def _stream_request_with_tools(
             # If tool_executables is not set, return the tool calls without executing them,
             # allowing the caller to manage the tool call loop.
             if tool_executables is None:
-                yield BotMessage(text="", tool_calls=tool_call_deltas)
+                yield BotMessage(
+                    text="", tool_calls=tool_call_deltas, index=message.index
+                )
                 continue
 
             for tool_call_delta in tool_call_deltas:
@@ -564,7 +566,9 @@ async def _stream_request_with_tools(
 
         # if no tool calls are selected, the deltas contain content instead of tool_calls
         elif "content" in message.data["choices"][0]["delta"]:
-            yield BotMessage(text=message.data["choices"][0]["delta"]["content"])
+            yield BotMessage(
+                text=message.data["choices"][0]["delta"]["content"], index=message.index
+            )
 
     # If tool_executables is not set, exit early since there are no functions to execute.
     if not tool_executables:


### PR DESCRIPTION
## Description

Fixed an issue where tool call responses had `index=None` instead of preserving the index from the incoming message, which was inconsistent with other partial responses.

## Changes Made

- Fixed `_stream_request_with_tools` to preserve the `index` field when yielding tool call responses
- Updated tool call response to pass through `index` field from incoming message (matching behavior of other partial responses)
- Added test case to verify index preservation in tool call responses
- Bumped version to 0.0.82

## Testing Done

- Verified fix works correctly with manual test
- Existing tool call tests continue to pass
- Added new test case `test_stream_request_with_tools_index_preserved` to verify index preservation

## Version

- Updated to version 0.0.82

## Breaking Changes

- None

## Checklist

- [x] Tests added
- [ ] Documentation updated (not needed for this bug fix)
- [x] Version bumped
- [x] Changes tested locally