### PR TITLE
feat: Add description field to SettingsResponse

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -565,6 +565,7 @@ Anthropic.
  messages if there is a multientity context.
 - `parameter_controls` (`Optional[ParameterControls] = None`): Optional JSON object that defines
 interactive parameter controls. The object must contain an api_version and sections array.
+- `description` (`str = ""`): A description of the bot.
 
 
 

--- a/src/fastapi_poe/types.py
+++ b/src/fastapi_poe/types.py
@@ -677,6 +677,7 @@ class SettingsResponse(BaseModel):
     messages if there is a multientity context.
     - `parameter_controls` (`Optional[ParameterControls] = None`): Optional JSON object that defines
     interactive parameter controls. The object must contain an api_version and sections array.
+    - `description` (`str = ""`): A description of the bot.
 
     """
 
@@ -697,6 +698,7 @@ class SettingsResponse(BaseModel):
     rate_card: Optional[str] = None
     cost_label: Optional[str] = None
     parameter_controls: Optional[ParameterControls] = None
+    description: Optional[str] = None
 
 
 class AttachmentUploadResponse(BaseModel):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -20,6 +20,10 @@ class TestSettingsResponse:
         response = SettingsResponse()
         assert response.response_version == 2
 
+    def test_description(self) -> None:
+        response = SettingsResponse(description="My bot description")
+        assert response.description == "My bot description"
+
 
 def test_extra_attrs() -> None:
     with pytest.raises(pydantic.ValidationError):


### PR DESCRIPTION
Adds the description field to SettingsResponse to allow setting bot description via the API.

Would allow bot's provide their description via code